### PR TITLE
Ensure return value is true if any ROI is active

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -12,7 +12,7 @@
     <PackageOutputPath>..\..\bin\$(Configuration)</PackageOutputPath>
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.3.0-test120218</Version>
+    <Version>0.3.0-test130201</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/RegionContainsPoint.cs
+++ b/src/Aeon.Acquisition/RegionContainsPoint.cs
@@ -24,7 +24,10 @@ namespace Aeon.Acquisition
             {
                 using (var contourHeader = Mat.CreateMatHeader(contour[i], contour[i].Length, 2, Depth.S32, 1))
                 {
-                    return CV.PointPolygonTest(contourHeader, point, false) > 0;
+                    if (CV.PointPolygonTest(contourHeader, point, false) > 0)
+                    {
+                        return true;
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR enforces an inclusive-OR behavior for multi-area polygonal ROIs, where activating any of the areas will return a boolean `True` value.

Fixes #108 