### PR TITLE
Ensure timestamp propagation for all derived wheel values

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -12,7 +12,7 @@
     <PackageOutputPath>..\..\bin\$(Configuration)</PackageOutputPath>
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.3.0-test141847</Version>
+    <Version>0.3.0-test151247</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/PatchController.bonsai
+++ b/src/Aeon.Acquisition/PatchController.bonsai
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.0"
+<WorkflowBuilder Version="2.7.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns:p1="clr-namespace:Bonsai.Harp.Expander;assembly=Bonsai.Harp.Expander"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>Contains control and acquisition functionality for a foraging patch.</Description>
@@ -77,8 +78,14 @@
         <Combinator xsi:type="rx:Merge" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="p1:OutputExpander">
-          <p1:PortName />
+        <Combinator xsi:type="harp:Device">
+          <harp:DeviceState>Active</harp:DeviceState>
+          <harp:DumpRegisters>true</harp:DumpRegisters>
+          <harp:LedState>On</harp:LedState>
+          <harp:VisualIndicators>On</harp:VisualIndicators>
+          <harp:Heartbeat>Enable</harp:Heartbeat>
+          <harp:IgnoreErrors>false</harp:IgnoreErrors>
+          <harp:PortName />
         </Combinator>
       </Expression>
       <Expression xsi:type="rx:PublishSubject">
@@ -86,15 +93,35 @@
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
       <Expression xsi:type="p1:MagneticEncoder">
-        <p1:IncludeTimestamp>false</p1:IncludeTimestamp>
+        <p1:IncludeTimestamp>true</p1:IncludeTimestamp>
       </Expression>
-      <Expression xsi:type="MemberSelector">
-        <Selector>Angle</Selector>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="aeon:WheelDisplacement">
-          <aeon:Radius>4</aeon:Radius>
-        </Combinator>
+      <Expression xsi:type="aeon:TransformTimestamped">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Angle</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Radius" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="aeon:WheelDisplacement">
+                <aeon:Radius>4</aeon:Radius>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="3" Label="Source1" />
+            <Edge From="2" To="3" Label="Source2" />
+            <Edge From="3" To="4" Label="Source1" />
+          </Edges>
+        </Workflow>
+        <aeon:IncludeTimestamp>false</aeon:IncludeTimestamp>
       </Expression>
       <Expression xsi:type="rx:PublishSubject">
         <Name>WheelDisplacement</Name>
@@ -127,25 +154,24 @@
     </Nodes>
     <Edges>
       <Edge From="0" To="11" Label="Source2" />
-      <Edge From="1" To="17" Label="Source2" />
-      <Edge From="2" To="20" Label="Source2" />
+      <Edge From="1" To="16" Label="Source2" />
+      <Edge From="2" To="19" Label="Source2" />
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="5" Label="Source1" />
       <Edge From="5" To="10" Label="Source2" />
       <Edge From="6" To="12" Label="Source2" />
-      <Edge From="7" To="16" Label="Source2" />
+      <Edge From="7" To="15" Label="Source2" />
       <Edge From="8" To="9" Label="Source1" />
       <Edge From="9" To="10" Label="Source1" />
       <Edge From="10" To="11" Label="Source1" />
       <Edge From="11" To="12" Label="Source1" />
       <Edge From="12" To="13" Label="Source1" />
       <Edge From="12" To="14" Label="Source1" />
-      <Edge From="12" To="18" Label="Source1" />
+      <Edge From="12" To="17" Label="Source1" />
       <Edge From="14" To="15" Label="Source1" />
       <Edge From="15" To="16" Label="Source1" />
-      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="17" To="18" Label="Source1" />
       <Edge From="18" To="19" Label="Source1" />
-      <Edge From="19" To="20" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/TimeSpentOnWheel.bonsai
+++ b/src/Aeon.Acquisition/TimeSpentOnWheel.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.0"
+<WorkflowBuilder Version="2.7.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns:dsp="clr-namespace:Bonsai.Dsp;assembly=Bonsai.Dsp"
@@ -29,6 +29,9 @@
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>WheelPatch1</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value</Selector>
       </Expression>
       <Expression xsi:type="rx:Accumulate" />
       <Expression xsi:type="ExternalizedMapping">
@@ -60,17 +63,18 @@
       <Edge From="0" To="1" Label="Source1" />
       <Edge From="1" To="2" Label="Source1" />
       <Edge From="2" To="3" Label="Source1" />
-      <Edge From="3" To="11" Label="Source1" />
+      <Edge From="3" To="12" Label="Source1" />
       <Edge From="4" To="5" Label="Source1" />
       <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="8" Label="Source1" />
-      <Edge From="7" To="8" Label="Source2" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="11" Label="Source2" />
-      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
       <Edge From="12" To="13" Label="Source1" />
       <Edge From="13" To="14" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/TransformTimestamped.cs
+++ b/src/Aeon.Acquisition/TransformTimestamped.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+using Bonsai;
+using Bonsai.Expressions;
+using Bonsai.Harp;
+
+namespace Aeon.Acquisition
+{
+    [DefaultProperty(nameof(IncludeTimestamp))]
+    [Description("Applies a transformation to the elements of an observable sequence using the encapsulated workflow and preserves the timestamp of each element.")]
+    public class TransformTimestamped : WorkflowExpressionBuilder
+    {
+        static readonly Range<int> argumentRange = Range.Create(lowerBound: 1, upperBound: 1);
+
+        public TransformTimestamped()
+        {
+        }
+
+        public TransformTimestamped(ExpressionBuilderGraph workflow)
+            : base(workflow)
+        {
+        }
+
+        public override Range<int> ArgumentRange => argumentRange;
+
+        public bool IncludeTimestamp { get; set; }
+
+        public override Expression Build(IEnumerable<Expression> arguments)
+        {
+            var source = arguments.FirstOrDefault();
+            if (source == null)
+            {
+                throw new InvalidOperationException("There must be at least one input to the transform workflow.");
+            }
+
+            var parameterType = source.Type.GetGenericArguments()[0];
+            if (!parameterType.IsGenericType || parameterType.GetGenericTypeDefinition() != typeof(Timestamped<>))
+            {
+                throw new InvalidOperationException("The input to the transform workflow must be Harp timestamped.");
+            }
+
+            // Assign input
+            var timestampedType = parameterType.GetGenericArguments()[0];
+            var selectorParameter = Expression.Parameter(IncludeTimestamp ? source.Type : typeof(IObservable<>).MakeGenericType(timestampedType));
+            return BuildWorkflow(arguments, selectorParameter, selectorBody =>
+            {
+                var selector = Expression.Lambda(selectorBody, selectorParameter);
+                var selectorObservableType = selector.ReturnType.GetGenericArguments()[0];
+                return Expression.Call(GetType(), nameof(Process), new[] { timestampedType, selectorObservableType }, source, selector);
+            });
+        }
+
+        static IObservable<Timestamped<TResult>> Process<TSource, TResult>(IObservable<Timestamped<TSource>> source, Func<IObservable<Timestamped<TSource>>, IObservable<TResult>> selector)
+        {
+            return source.Publish(ps => ps
+                .Select(value => value.Seconds)
+                .Zip(selector(ps), (seconds, value) => Timestamped.Create(value, seconds)));
+        }
+
+        static IObservable<Timestamped<TResult>> Process<TSource, TResult>(IObservable<Timestamped<TSource>> source, Func<IObservable<TSource>, IObservable<TResult>> selector)
+        {
+            return source.Publish(ps => ps
+                .Select(input => input.Seconds)
+                .Zip(selector(ps.Select(input => input.Value)), (seconds, value) => Timestamped.Create(value, seconds)));
+        }
+    }
+}

--- a/src/Aeon.Acquisition/UndergroundFeeder.bonsai
+++ b/src/Aeon.Acquisition/UndergroundFeeder.bonsai
@@ -251,15 +251,35 @@ Item2.GetTimestamp() as Seconds)</scr:Expression>
         <Name>PatchEvents</Name>
       </Expression>
       <Expression xsi:type="p1:MagneticEncoder">
-        <p1:IncludeTimestamp>false</p1:IncludeTimestamp>
+        <p1:IncludeTimestamp>true</p1:IncludeTimestamp>
       </Expression>
-      <Expression xsi:type="MemberSelector">
-        <Selector>Angle</Selector>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="aeon:WheelDisplacement">
-          <aeon:Radius>4</aeon:Radius>
-        </Combinator>
+      <Expression xsi:type="aeon:TransformTimestamped">
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Angle</Selector>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Radius" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="aeon:WheelDisplacement">
+                <aeon:Radius>4</aeon:Radius>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="3" Label="Source1" />
+            <Edge From="2" To="3" Label="Source2" />
+            <Edge From="3" To="4" Label="Source1" />
+          </Edges>
+        </Workflow>
+        <aeon:IncludeTimestamp>false</aeon:IncludeTimestamp>
       </Expression>
       <Expression xsi:type="rx:PublishSubject">
         <Name>WheelDisplacement</Name>
@@ -292,8 +312,8 @@ Item2.GetTimestamp() as Seconds)</scr:Expression>
     </Nodes>
     <Edges>
       <Edge From="0" To="20" Label="Source2" />
-      <Edge From="1" To="28" Label="Source2" />
-      <Edge From="2" To="31" Label="Source2" />
+      <Edge From="1" To="27" Label="Source2" />
+      <Edge From="2" To="30" Label="Source2" />
       <Edge From="2" To="3" Label="Source1" />
       <Edge From="3" To="16" Label="Source2" />
       <Edge From="4" To="5" Label="Source1" />
@@ -302,7 +322,7 @@ Item2.GetTimestamp() as Seconds)</scr:Expression>
       <Edge From="6" To="7" Label="Source1" />
       <Edge From="6" To="22" Label="Source2" />
       <Edge From="7" To="8" Label="Source1" />
-      <Edge From="9" To="27" Label="Source2" />
+      <Edge From="9" To="26" Label="Source2" />
       <Edge From="10" To="11" Label="Source1" />
       <Edge From="11" To="19" Label="Source1" />
       <Edge From="12" To="13" Label="Source1" />
@@ -319,12 +339,11 @@ Item2.GetTimestamp() as Seconds)</scr:Expression>
       <Edge From="22" To="23" Label="Source2" />
       <Edge From="23" To="24" Label="Source1" />
       <Edge From="24" To="25" Label="Source1" />
-      <Edge From="24" To="29" Label="Source1" />
+      <Edge From="24" To="28" Label="Source1" />
       <Edge From="25" To="26" Label="Source1" />
       <Edge From="26" To="27" Label="Source1" />
-      <Edge From="27" To="28" Label="Source1" />
+      <Edge From="28" To="29" Label="Source1" />
       <Edge From="29" To="30" Label="Source1" />
-      <Edge From="30" To="31" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR modifies both the underground and overground feeder modules to work always with timestamped displacement. This will allow updating the tasks to log the exact timestamp of the sample that caused a change in patch state.

Fixes #113 