### PR TITLE
Validate environment state during subject changes

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -12,7 +12,7 @@
     <PackageOutputPath>..\..\bin\$(Configuration)</PackageOutputPath>
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.3.0-test181040</Version>
+    <Version>0.3.0-test191757</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/EnvironmentSubjectState.cs
+++ b/src/Aeon.Acquisition/EnvironmentSubjectState.cs
@@ -20,6 +20,11 @@ namespace Aeon.Acquisition
         [FileNameFilter("CSV (Comma delimited)|*.csv|All Files|*.*")]
         public string DatabasePath { get; set; }
 
+        [Description("The current state of the environment.")]
+        public EnvironmentStateType? EnvironmentState { get; set; }
+
+        public bool ShouldSerializeEnvironmentState() => EnvironmentState.HasValue;
+
         string INamedElement.Name => $"{Name.AsNullIfEmpty() ?? "Environment"}SubjectState";
 
         internal SubjectStateRecovery State { get; set; }

--- a/src/Aeon.Acquisition/EnvironmentSubjectStateControl.cs
+++ b/src/Aeon.Acquisition/EnvironmentSubjectStateControl.cs
@@ -70,6 +70,19 @@ namespace Aeon.Acquisition
             return true;
         }
 
+        private bool ValidateEnvironment(EnvironmentStateType? environmentState)
+        {
+            if (environmentState.HasValue && environmentState != EnvironmentStateType.Maintenance)
+            {
+                MessageBox.Show(
+                    $"Any changes to the list of active subjects must be made during maintenance mode.",
+                    ((Bonsai.INamedElement)Source).Name);
+                return false;
+            }
+
+            return true;
+        }
+
         private void RefreshViewState(ViewState view)
         {
             viewState = view;
@@ -98,6 +111,7 @@ namespace Aeon.Acquisition
         {
             if (viewState == ViewState.Browse)
             {
+                if (!ValidateEnvironment(Source.EnvironmentState)) return;
                 var metadata = new EnvironmentSubjectStateEntry { Type = EnvironmentSubjectChangeType.Enter };
                 propertyGrid.SelectedObject = metadata;
                 RefreshViewState(ViewState.Adding);
@@ -143,7 +157,7 @@ namespace Aeon.Acquisition
             if (viewState == ViewState.Browse)
             {
                 var selectedItem = subjectListView.SelectedItems.OfType<ListViewItem>().FirstOrDefault();
-                if (selectedItem != null)
+                if (selectedItem != null && ValidateEnvironment(Source.EnvironmentState))
                 {
                     var metadata = (EnvironmentSubjectStateEntry)selectedItem.Tag;
                     propertyGrid.SelectedObject = new EnvironmentSubjectStateEntry


### PR DESCRIPTION
This PR adds an optional validation state to the subject state source to ensure that changes to the active subject list can only be made during Maintenance mode. This makes it easier to ensure predictable protocol when adding / removing subjects on the arena.

Fixes https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/177