### PR TITLE
Ensure epoch timestamps are logged in UTC

### DIFF
--- a/src/Aeon.Acquisition/LogController.bonsai
+++ b/src/Aeon.Acquisition/LogController.bonsai
@@ -20,7 +20,7 @@
         <Combinator xsi:type="rx:Timestamp" />
       </Expression>
       <Expression xsi:type="MemberSelector">
-        <Selector>Timestamp.DateTime</Selector>
+        <Selector>Timestamp.UtcDateTime</Selector>
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:FormatDate" />


### PR DESCRIPTION
This PR changes the `LogController` module to read the epoch timestamp in UTC, which should make all logged data independent of local computer time zone.

Fixes #103 