### PR TITLE
Allow flushing chunks automatically using heartbeat source

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -12,7 +12,7 @@
     <PackageOutputPath>..\..\bin\$(Configuration)</PackageOutputPath>
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.3.0-test201312</Version>
+    <Version>0.3.0-test211418</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/GroupByTime.cs
+++ b/src/Aeon.Acquisition/GroupByTime.cs
@@ -1,9 +1,11 @@
-using Bonsai;
+﻿using Bonsai;
 using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Reactive.Linq;
 using Bonsai.Harp;
+using System.Xml.Serialization;
+using System.Xml;
 
 namespace Aeon.Acquisition
 {
@@ -22,6 +24,27 @@ namespace Aeon.Acquisition
 
         [Description("The size of each chunk, in whole hours.")]
         public int ChunkSize { get; set; }
+
+        [XmlIgnore]
+        [Description("The relative time at which each group will close following the end of the chunk.")]
+        public TimeSpan? ClosingDuration { get; set; }
+
+        [Browsable(false)]
+        [XmlElement(nameof(ClosingDuration))]
+        public string ClosingDurationXml
+        {
+            get
+            {
+                var timeShift = ClosingDuration;
+                if (timeShift.HasValue) return XmlConvert.ToString(timeShift.Value);
+                else return null;
+            }
+            set
+            {
+                if (!string.IsNullOrEmpty(value)) ClosingDuration = XmlConvert.ToTimeSpan(value);
+                else ClosingDuration = null;
+            }
+        }
 
         DateTime GetChunkIndex(double seconds)
         {
@@ -43,6 +66,40 @@ namespace Aeon.Acquisition
         public IObservable<IGroupedObservable<DateTime, Timestamped<TSource>>> Process<TSource>(IObservable<Tuple<TSource, double>> source)
         {
             return source.GroupBy(value => GetChunkIndex(value.Item2), value => Timestamped.Create(value.Item1, value.Item2));
+        }
+
+        bool ShouldCloseChunk<TElement>(IGroupedObservable<DateTime, TElement> chunk, HarpMessage heartbeat)
+        {
+            var beatTimestamp = ReferenceTime.AddSeconds(heartbeat.GetTimestamp());
+            var beatDelta = beatTimestamp - chunk.Key;
+            return beatDelta > new TimeSpan(ChunkSize, 0, 0) + ClosingDuration;
+        }
+
+        public IObservable<IGroupedObservable<DateTime, Timestamped<TSource>>> Process<TSource>(
+            IObservable<Timestamped<TSource>> source,
+            IObservable<HarpMessage> heartbeats)
+        {
+            return source.GroupByUntil(
+                value => GetChunkIndex(value.Seconds),
+                chunk => heartbeats.FirstOrDefaultAsync(message => ShouldCloseChunk(chunk, message)));
+        }
+
+        public IObservable<IGroupedObservable<DateTime, HarpMessage>> Process(
+            IObservable<HarpMessage> source,
+            IObservable<HarpMessage> heartbeats)
+        {
+            return source.GroupByUntil(
+                value => GetChunkIndex(value.GetTimestamp()),
+                chunk => heartbeats.FirstOrDefaultAsync(message => ShouldCloseChunk(chunk, message)));
+        }
+
+        public IObservable<IGroupedObservable<DateTime, Timestamped<TSource>>> Process<TSource>(
+            IObservable<Tuple<TSource, double>> source,
+            IObservable<HarpMessage> heartbeats)
+        {
+            return source.GroupByUntil(
+                value => GetChunkIndex(value.Item2), value => Timestamped.Create(value.Item1, value.Item2),
+                chunk => heartbeats.FirstOrDefaultAsync(message => ShouldCloseChunk(chunk, message)));
         }
     }
 }

--- a/src/Aeon.Acquisition/LogAudio.bonsai
+++ b/src/Aeon.Acquisition/LogAudio.bonsai
@@ -11,6 +11,12 @@
       <Expression xsi:type="WorkflowInput">
         <Name>Source1</Name>
       </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="Heartbeats" Description="The source of heartbeat signals used as a timing signal for closing groups." Category="GroupClosing" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name />
+      </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>ChunkSize</Name>
       </Expression>
@@ -18,6 +24,9 @@
         <PropertyMappings>
           <Property Name="ChunkSize" />
         </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ClosingDuration" Category="GroupClosing" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
@@ -57,8 +66,8 @@
               <Property Name="Name" />
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FormatFileName.bonsai">
-              <Extension>wav</Extension>
               <Name>AudioData</Name>
+              <Extension>wav</Extension>
             </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
@@ -100,13 +109,16 @@
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="3" Label="Source1" />
+      <Edge From="0" To="6" Label="Source1" />
       <Edge From="1" To="2" Label="Source1" />
-      <Edge From="2" To="3" Label="Source2" />
-      <Edge From="3" To="5" Label="Source1" />
-      <Edge From="4" To="5" Label="Source2" />
-      <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="2" To="6" Label="Source2" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="6" Label="Source3" />
+      <Edge From="5" To="6" Label="Source4" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/LogData.bonsai
+++ b/src/Aeon.Acquisition/LogData.bonsai
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <WorkflowBuilder Version="2.7.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
@@ -11,6 +11,12 @@
       <Expression xsi:type="WorkflowInput">
         <Name>Source1</Name>
       </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="Heartbeats" Description="The source of heartbeat signals used as a timing signal for closing groups." Category="GroupClosing" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name />
+      </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>ChunkSize</Name>
       </Expression>
@@ -18,6 +24,9 @@
         <PropertyMappings>
           <Property Name="ChunkSize" />
         </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ClosingDuration" Category="GroupClosing" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
@@ -54,8 +63,8 @@
               <Property Name="Name" />
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FormatFileName.bonsai">
-              <Extension>csv</Extension>
               <Name>Data</Name>
+              <Extension>csv</Extension>
             </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
@@ -94,13 +103,16 @@
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="3" Label="Source1" />
+      <Edge From="0" To="6" Label="Source1" />
       <Edge From="1" To="2" Label="Source1" />
-      <Edge From="2" To="3" Label="Source2" />
-      <Edge From="3" To="5" Label="Source1" />
-      <Edge From="4" To="5" Label="Source2" />
-      <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="2" To="6" Label="Source2" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="6" Label="Source3" />
+      <Edge From="5" To="6" Label="Source4" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/LogHarp.bonsai
+++ b/src/Aeon.Acquisition/LogHarp.bonsai
@@ -11,6 +11,10 @@
       <Expression xsi:type="WorkflowInput">
         <Name>Source1</Name>
       </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="Heartbeats" Description="The source of heartbeat signals used as a timing signal for closing groups." Category="GroupClosing" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject" />
       <Expression xsi:type="SubscribeSubject">
         <Name>ChunkSize</Name>
       </Expression>
@@ -18,6 +22,9 @@
         <PropertyMappings>
           <Property Name="ChunkSize" />
         </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ClosingDuration" Category="GroupClosing" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
@@ -56,8 +63,8 @@
               <Property Name="Name" />
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FormatFileName.bonsai">
-              <Extension>bin</Extension>
               <Name>HarpData</Name>
+              <Extension>bin</Extension>
             </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
@@ -93,13 +100,16 @@
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="3" Label="Source1" />
+      <Edge From="0" To="6" Label="Source1" />
       <Edge From="1" To="2" Label="Source1" />
-      <Edge From="2" To="3" Label="Source2" />
-      <Edge From="3" To="5" Label="Source1" />
-      <Edge From="4" To="5" Label="Source2" />
-      <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="2" To="6" Label="Source2" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="6" Label="Source3" />
+      <Edge From="5" To="6" Label="Source4" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/LogHarpDemux.bonsai
+++ b/src/Aeon.Acquisition/LogHarpDemux.bonsai
@@ -17,6 +17,8 @@
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="LogName" />
+        <Property Name="Heartbeats" />
+        <Property Name="ClosingDuration" />
       </Expression>
       <Expression xsi:type="rx:SelectMany">
         <Name>LogRegisters</Name>
@@ -27,12 +29,6 @@
             </Expression>
             <Expression xsi:type="rx:AsyncSubject">
               <Name>Register</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>Register</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Key</Selector>
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
               <Property Name="Value" DisplayName="LogName" />
@@ -46,6 +42,12 @@
               <Combinator xsi:type="rx:Take">
                 <rx:Count>1</rx:Count>
               </Combinator>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Register</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Key</Selector>
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:Zip" />
@@ -63,6 +65,12 @@
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:Merge" />
             </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Name" DisplayName="Heartbeats" Description="The source of heartbeat signals used as a timing signal for closing groups." Category="GroupClosing" />
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name />
+            </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>ChunkSize</Name>
             </Expression>
@@ -70,6 +78,9 @@
               <PropertyMappings>
                 <Property Name="ChunkSize" />
               </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="ClosingDuration" Category="GroupClosing" />
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="aeon:GroupByTime">
@@ -110,8 +121,8 @@
                     </PropertyMappings>
                   </Expression>
                   <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FormatFileName.bonsai">
-                    <Extension>bin</Extension>
                     <Name>HarpData</Name>
+                    <Extension>bin</Extension>
                   </Expression>
                   <Expression xsi:type="PropertyMapping">
                     <PropertyMappings>
@@ -150,19 +161,22 @@
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="3" To="7" Label="Source2" />
-            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="3" To="4" Label="Source1" />
+            <Edge From="4" To="7" Label="Source1" />
             <Edge From="5" To="6" Label="Source1" />
-            <Edge From="6" To="7" Label="Source1" />
+            <Edge From="6" To="7" Label="Source2" />
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source1" />
             <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="14" Label="Source1" />
+            <Edge From="11" To="17" Label="Source1" />
             <Edge From="12" To="13" Label="Source1" />
-            <Edge From="13" To="14" Label="Source2" />
+            <Edge From="13" To="17" Label="Source2" />
             <Edge From="14" To="15" Label="Source1" />
-            <Edge From="15" To="16" Label="Source1" />
-            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="15" To="17" Label="Source3" />
+            <Edge From="16" To="17" Label="Source4" />
+            <Edge From="17" To="18" Label="Source1" />
+            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="19" To="20" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Aeon.Acquisition/LogHarpState.bonsai
+++ b/src/Aeon.Acquisition/LogHarpState.bonsai
@@ -12,14 +12,20 @@
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="harp:FilterMessage">
-          <harp:Address xsi:nil="true" />
           <harp:MessageType>Read</harp:MessageType>
+          <harp:Register xsi:type="harp:FilterMessageAddress">
+            <harp:Address xsi:nil="true" />
+          </harp:Register>
         </Combinator>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="LogName" />
+        <Property Name="Heartbeats" />
+        <Property Name="ClosingDuration" />
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarp.bonsai">
+        <Heartbeats xsi:nil="true" />
+        <ClosingDuration xsi:nil="true" />
         <LogName>HarpData</LogName>
       </Expression>
       <Expression xsi:type="rx:Condition">
@@ -48,6 +54,8 @@
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarpDemux.bonsai">
         <LogName>HarpData</LogName>
+        <Heartbeats />
+        <ClosingDuration xsi:nil="true" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Merge" />

--- a/src/Aeon.Acquisition/LogVideo.bonsai
+++ b/src/Aeon.Acquisition/LogVideo.bonsai
@@ -12,6 +12,12 @@
       <Expression xsi:type="WorkflowInput">
         <Name>Source1</Name>
       </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="Heartbeats" Description="The source of heartbeat signals used as a timing signal for closing groups." Category="GroupClosing" />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name />
+      </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>ChunkSize</Name>
       </Expression>
@@ -19,6 +25,9 @@
         <PropertyMappings>
           <Property Name="ChunkSize" />
         </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ClosingDuration" Category="GroupClosing" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
@@ -51,18 +60,12 @@
             <Expression xsi:type="MemberSelector">
               <Selector>Key</Selector>
             </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>Data</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Key</Selector>
-            </Expression>
             <Expression xsi:type="ExternalizedMapping">
               <Property Name="Name" />
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FormatFileName.bonsai">
-              <Extension>csv</Extension>
               <Name>VideoData</Name>
+              <Extension>csv</Extension>
             </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
@@ -79,9 +82,15 @@
             <Expression xsi:type="MemberSelector">
               <Selector>Value.Image</Selector>
             </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>Data</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Key</Selector>
+            </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:FormatFileName.bonsai">
-              <Extension>avi</Extension>
               <Name>VideoData</Name>
+              <Extension>avi</Extension>
             </Expression>
             <Expression xsi:type="PropertyMapping">
               <PropertyMappings>
@@ -110,17 +119,17 @@
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
             <Edge From="2" To="3" Label="Source1" />
-            <Edge From="3" To="11" Label="Source1" />
+            <Edge From="3" To="9" Label="Source1" />
             <Edge From="4" To="5" Label="Source1" />
-            <Edge From="5" To="9" Label="Source1" />
-            <Edge From="6" To="7" Label="Source1" />
-            <Edge From="7" To="13" Label="Source1" />
+            <Edge From="5" To="7" Label="Source1" />
+            <Edge From="6" To="7" Label="Source2" />
+            <Edge From="6" To="13" Label="Source2" />
+            <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source2" />
-            <Edge From="8" To="13" Label="Source2" />
             <Edge From="9" To="10" Label="Source1" />
-            <Edge From="10" To="11" Label="Source2" />
+            <Edge From="10" To="16" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="16" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="16" Label="Source2" />
             <Edge From="15" To="16" Label="Source3" />
@@ -134,13 +143,16 @@
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="3" Label="Source1" />
+      <Edge From="0" To="6" Label="Source1" />
       <Edge From="1" To="2" Label="Source1" />
-      <Edge From="2" To="3" Label="Source2" />
-      <Edge From="3" To="5" Label="Source1" />
-      <Edge From="4" To="5" Label="Source2" />
-      <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="2" To="6" Label="Source2" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="6" Label="Source3" />
+      <Edge From="5" To="6" Label="Source4" />
+      <Edge From="6" To="8" Label="Source1" />
+      <Edge From="7" To="8" Label="Source2" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR extends the functionality of `GroupByTime` and all Aeon logging operators to allow flushing time chunks using the Heartbeat stream of the clock synchronizer.

This is core infrastructure to resolve https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/192 where sparse data streams could be left several minutes or hours without being flushed to disk until an epoch was terminated or a late event arrived that triggered chunk transition.

In this new approach, the logging operators can be optionally provided with a `Heartbeat` source which acts as a permanent trigger for closing time chunks, and an optional `ClosingDuration` time span specifying how much time to wait following chunk transition before the current chunk is flushed.