### PR TITLE
Add operator to convert Sleap Pose types to HarpMessage

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -26,12 +26,12 @@
     <PackageReference Include="Bonsai.Harp.Expander" Version="0.1.0-build1534" />
     <PackageReference Include="Bonsai.Osc" Version="2.7.0" />
     <PackageReference Include="Bonsai.Pylon" Version="0.3.0" />
+    <PackageReference Include="Bonsai.Sleap" Version="0.2.0" />
     <PackageReference Include="Bonsai.Spinnaker" Version="0.7.1-rc" />
     <PackageReference Include="Bonsai.Design" Version="2.7.0" />
     <PackageReference Include="Bonsai.System" Version="2.7.0" />
     <PackageReference Include="Bonsai.Scripting.Expressions" Version="2.7.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.4" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
     <PackageReference Include="Bonsai.Vision" Version="2.7.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.5.1" />
   </ItemGroup>

--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -12,7 +12,7 @@
     <PackageOutputPath>..\..\bin\$(Configuration)</PackageOutputPath>
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.3.0-test211418</Version>
+    <Version>0.3.0-test221337</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/FormatPose.cs
+++ b/src/Aeon.Acquisition/FormatPose.cs
@@ -11,7 +11,7 @@ namespace Aeon.Acquisition
     [Combinator]
     [Description("Converts a timestamped pose collection into a sequence of Harp messages.")]
     [WorkflowElementCategory(ElementCategory.Transform)]
-    public class FormatSleapPose
+    public class FormatPose
     {
         [Description("The address of the formatted Harp message.")]
         public int Address { get; set; } = 255;

--- a/src/Aeon.Acquisition/FormatSleapPose.cs
+++ b/src/Aeon.Acquisition/FormatSleapPose.cs
@@ -1,0 +1,110 @@
+﻿using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai.Sleap;
+using Bonsai.Harp;
+using OpenCV.Net;
+using System.Drawing;
+using Bonsai.Reactive;
+
+namespace Aeon.Acquisition 
+{
+        [Combinator]
+        [Description("Converts a timestamped sleap pose collection into a sequence of Harp messages. " +
+        "The output will take the form of: ArgMaxId, IdConf, N*[PartA.X, PartA.Y, PartA.Conf]")]
+        [WorkflowElementCategory(ElementCategory.Transform)]
+        public class FormatSleapPose
+        {
+            public int Address { get; set; } = 255;
+
+            [Description("Optional value to override the ArgMax value returned by the predict Sleap operator.")]
+            public int? Id { get; set; }
+
+            public IObservable<HarpMessage> Process(IObservable<Tuple<PoseIdentity,double>> source)
+            {
+                return source.Select(value => {
+                    var pose = value.Item1;
+                    var timestamp = value.Item2;
+                    var data = new float[2 + pose.Count*3];
+                    data[0] = Id == null ? (float) pose.IdentityIndex : (float) Id;
+                    data[1] = pose.Confidence;
+                    int i = 1;
+                    foreach (var bp in (pose))
+                    {
+                        data[++i] = bp.Position.X;
+                        data[++i] = bp.Position.Y;
+                        data[++i] = bp.Confidence;
+                    }
+                    return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
+                });
+            }
+
+        public IObservable<HarpMessage> Process(IObservable<Tuple<PoseIdentityCollection, double>> source)
+        {
+            return source.SelectMany(value =>
+            {
+                var poseCollection = value.Item1;
+                var timestamp = value.Item2;
+                return poseCollection.Select((pose, index) =>
+                {
+                    var data = new float[2 + pose.Count * 3];
+                    data[0] = Id == null ? (float)pose.IdentityIndex : (float) Id;
+                    data[1] = pose.Confidence;
+                    int i = 1;
+                    foreach (var bp in (pose))
+                    {
+                        data[++i] = bp.Position.X;
+                        data[++i] = bp.Position.Y;
+                        data[++i] = bp.Confidence;
+                    }
+                    return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
+                });
+            });
+        }
+
+        public IObservable<HarpMessage> Process(IObservable<Tuple<Pose, double>> source)
+            {
+                return source.Select(value => {
+                    var pose = value.Item1;
+                    var timestamp = value.Item2;
+                    var data = new float[2 + pose.Count * 3];
+                    data[0] = Id == null ? -1F : (float) Id;
+                    data[1] = float.NaN;
+                    int i = 1;
+                    foreach (var bp in (pose))
+                    {
+                        data[++i] = bp.Position.X;
+                        data[++i] = bp.Position.Y;
+                        data[++i] = bp.Confidence;
+                    }
+                    return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
+                });
+            }
+
+        public IObservable<HarpMessage> Process(IObservable<Tuple<PoseCollection, double>> source)
+        {
+            return source.SelectMany(value =>
+            {
+                var poseCollection = value.Item1;
+                var timestamp = value.Item2;
+                return poseCollection.Select((pose, index) =>
+                {
+                    var data = new float[2 + pose.Count * 3];
+                    data[0] = Id == null ? index : (float) Id;
+                    data[1] = float.NaN;
+                    int i = 1;
+                    foreach (var bp in pose)
+                    {
+                        data[++i] = bp.Position.X;
+                        data[++i] = bp.Position.Y;
+                        data[++i] = bp.Confidence;
+                    }
+                    return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
+                });
+            });
+        }
+    }
+}

--- a/src/Aeon.Acquisition/FormatSleapPose.cs
+++ b/src/Aeon.Acquisition/FormatSleapPose.cs
@@ -1,46 +1,43 @@
 ﻿using Bonsai;
 using System;
 using System.ComponentModel;
-using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using Bonsai.Sleap;
 using Bonsai.Harp;
-using OpenCV.Net;
-using System.Drawing;
-using Bonsai.Reactive;
 
-namespace Aeon.Acquisition 
+namespace Aeon.Acquisition
 {
-        [Combinator]
-        [Description("Converts a timestamped sleap pose collection into a sequence of Harp messages. " +
-        "The output will take the form of: ArgMaxId, IdConf, N*[PartA.X, PartA.Y, PartA.Conf]")]
-        [WorkflowElementCategory(ElementCategory.Transform)]
-        public class FormatSleapPose
+    [Combinator]
+    [Description("Converts a timestamped pose collection into a sequence of Harp messages.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class FormatSleapPose
+    {
+        [Description("The address of the formatted Harp message.")]
+        public int Address { get; set; } = 255;
+
+        [Description("Optional value to override or set the identity index returned by the source pose.")]
+        public int? IdentityIndex { get; set; }
+
+        public IObservable<HarpMessage> Process(IObservable<Tuple<PoseIdentity, double>> source)
         {
-            public int Address { get; set; } = 255;
-
-            [Description("Optional value to override the ArgMax value returned by the predict Sleap operator.")]
-            public int? Id { get; set; }
-
-            public IObservable<HarpMessage> Process(IObservable<Tuple<PoseIdentity,double>> source)
+            return source.Select(value =>
             {
-                return source.Select(value => {
-                    var pose = value.Item1;
-                    var timestamp = value.Item2;
-                    var data = new float[2 + pose.Count*3];
-                    data[0] = Id == null ? (float) pose.IdentityIndex : (float) Id;
-                    data[1] = pose.Confidence;
-                    int i = 1;
-                    foreach (var bp in (pose))
-                    {
-                        data[++i] = bp.Position.X;
-                        data[++i] = bp.Position.Y;
-                        data[++i] = bp.Confidence;
-                    }
-                    return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
-                });
-            }
+                var pose = value.Item1;
+                var timestamp = value.Item2;
+                var data = new float[2 + pose.Count * 3];
+                data[0] = IdentityIndex == null ? pose.IdentityIndex : (float)IdentityIndex;
+                data[1] = pose.Confidence;
+                int i = 1;
+                foreach (var bp in pose)
+                {
+                    data[++i] = bp.Position.X;
+                    data[++i] = bp.Position.Y;
+                    data[++i] = bp.Confidence;
+                }
+                return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
+            });
+        }
 
         public IObservable<HarpMessage> Process(IObservable<Tuple<PoseIdentityCollection, double>> source)
         {
@@ -51,10 +48,10 @@ namespace Aeon.Acquisition
                 return poseCollection.Select((pose, index) =>
                 {
                     var data = new float[2 + pose.Count * 3];
-                    data[0] = Id == null ? (float)pose.IdentityIndex : (float) Id;
+                    data[0] = IdentityIndex == null ? pose.IdentityIndex : (float)IdentityIndex;
                     data[1] = pose.Confidence;
                     int i = 1;
-                    foreach (var bp in (pose))
+                    foreach (var bp in pose)
                     {
                         data[++i] = bp.Position.X;
                         data[++i] = bp.Position.Y;
@@ -66,23 +63,24 @@ namespace Aeon.Acquisition
         }
 
         public IObservable<HarpMessage> Process(IObservable<Tuple<Pose, double>> source)
+        {
+            return source.Select(value =>
             {
-                return source.Select(value => {
-                    var pose = value.Item1;
-                    var timestamp = value.Item2;
-                    var data = new float[2 + pose.Count * 3];
-                    data[0] = Id == null ? -1F : (float) Id;
-                    data[1] = float.NaN;
-                    int i = 1;
-                    foreach (var bp in (pose))
-                    {
-                        data[++i] = bp.Position.X;
-                        data[++i] = bp.Position.Y;
-                        data[++i] = bp.Confidence;
-                    }
-                    return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
-                });
-            }
+                var pose = value.Item1;
+                var timestamp = value.Item2;
+                var data = new float[2 + pose.Count * 3];
+                data[0] = IdentityIndex == null ? -1f : (float)IdentityIndex;
+                data[1] = float.NaN;
+                int i = 1;
+                foreach (var bp in pose)
+                {
+                    data[++i] = bp.Position.X;
+                    data[++i] = bp.Position.Y;
+                    data[++i] = bp.Confidence;
+                }
+                return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
+            });
+        }
 
         public IObservable<HarpMessage> Process(IObservable<Tuple<PoseCollection, double>> source)
         {
@@ -93,7 +91,7 @@ namespace Aeon.Acquisition
                 return poseCollection.Select((pose, index) =>
                 {
                     var data = new float[2 + pose.Count * 3];
-                    data[0] = Id == null ? index : (float) Id;
+                    data[0] = IdentityIndex == null ? index : (float)IdentityIndex;
                     data[1] = float.NaN;
                     int i = 1;
                     foreach (var bp in pose)


### PR DESCRIPTION
This PR adds a new operator `FormatPose` to convert the output of SLEAP predictions to a harp format.

The format of the output message will be:
```IdentityIndex, IdentityConf, N*[PartA.X, PartA.Y, PartA.Conf]```
Where N is the number of `BodyParts`.

The current overloads are of the type `Tuple<PoseType, double>` where `double` represents a timestamp in seconds.

`PoseType` can be of type:
 - `Pose` - IdentityIndex will default to -1
 - `PoseIdentity` - IdentityIndex will default to the ArgMax inferred by the network
 - `PoseCollection` - IdentityIndex will default to the index of the `Pose` inside the collection
 - `PoseIdentityCollection` - IdentityIndex will default to the ArgMax inferred by the network

If the `IdentityIndex` property is defined in the operator, the IdentityIndex in the HarpMessage will be overridden by this value.

