### PR TITLE
Add repository log controller module

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>test221337</VersionSuffix>
+    <VersionSuffix>test232251</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bonsai.Core" Version="2.7.1" />
+    <PackageReference Include="Bonsai.Core" Version="2.7.3" />
     <PackageReference Include="Bonsai.Audio" Version="2.7.0" />
     <PackageReference Include="Bonsai.Harp" Version="3.4.0" />
     <PackageReference Include="Bonsai.Harp.Expander" Version="0.1.0-build1534" />
@@ -23,8 +23,8 @@
     <PackageReference Include="Bonsai.Pylon" Version="0.3.0" />
     <PackageReference Include="Bonsai.Sleap" Version="0.2.0" />
     <PackageReference Include="Bonsai.Spinnaker" Version="0.7.1-rc" />
-    <PackageReference Include="Bonsai.Design" Version="2.7.0" />
-    <PackageReference Include="Bonsai.System" Version="2.7.0" />
+    <PackageReference Include="Bonsai.Design" Version="2.7.1" />
+    <PackageReference Include="Bonsai.System" Version="2.7.1" />
     <PackageReference Include="Bonsai.Scripting.Expressions" Version="2.7.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.4" />
     <PackageReference Include="Bonsai.Vision" Version="2.7.0" />

--- a/src/Aeon.Acquisition/RepositoryLogController.bonsai
+++ b/src/Aeon.Acquisition/RepositoryLogController.bonsai
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.7.3"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
+                 xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Description>Specifies how to initialize logging paths from a git repo.</Description>
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Path" DisplayName="RepositoryPath" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon:CreateRepository">
+          <aeon:Path>..\..\</aeon:Path>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon:IsRepositoryClean" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="DataPath" Description="The relative or absolute path of the clean data directory." />
+      </Expression>
+      <Expression xsi:type="PropertySource" TypeArguments="io:GetFiles,sys:String">
+        <MemberName>Path</MemberName>
+        <Value>data</Value>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="FallbackPath" Description="The relative or absolute path of the fallback data directory." />
+      </Expression>
+      <Expression xsi:type="PropertySource" TypeArguments="io:GetFiles,sys:String">
+        <MemberName>Path</MemberName>
+        <Value>devdata</Value>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="scr:ExpressionTransform">
+        <scr:Expression>new(
+Item1 as Repository,
+Item2 ? Item3 : Item4 as BasePath)</scr:Expression>
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{0}\{1}</Format>
+        <Selector>BasePath,Repository.Head.FriendlyName</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="Path" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ChunkSize" />
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogController.bonsai">
+        <Path>devdata</Path>
+        <ChunkSize>1</ChunkSize>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="1" To="9" Label="Source1" />
+      <Edge From="2" To="9" Label="Source2" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="9" Label="Source3" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source4" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="12" To="14" Label="Source1" />
+      <Edge From="13" To="14" Label="Source2" />
+      <Edge From="14" To="15" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>


### PR DESCRIPTION
This PR adds a new repository log controller module that uses the git API to retrieve at runtime the metadata for the current branch. The data directory is set to the target directory or a fallback directory depending on whether the current working directory is clean. Epoch data is copied into a subfolder of the data directory using the branch friendly name.

Provides common infrastructure for https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/186