### PR TITLE
Update export metadata to target venv

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>test241355</VersionSuffix>
+    <VersionSuffix>test250811</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/ExportMetadata.bonsai
+++ b/src/Aeon.Acquisition/ExportMetadata.bonsai
@@ -38,7 +38,7 @@
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="io:StartProcess">
-          <io:FileName>..\..\python\winpython\python-3.9.5.amd64\python.exe</io:FileName>
+          <io:FileName>..\..\python\.venv\Scripts\python.exe</io:FileName>
           <io:Arguments />
         </Combinator>
       </Expression>


### PR DESCRIPTION
This PR updates the export metadata operator to target a local virtual environment.

Provides common infrastructure for https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/248