### PR TITLE
Allow manually setting lower exposures

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>test250811</VersionSuffix>
+    <VersionSuffix>test261559</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/SpinnakerVideoSource.bonsai
+++ b/src/Aeon.Acquisition/SpinnakerVideoSource.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.0"
+<WorkflowBuilder Version="2.7.2"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -30,8 +30,18 @@
       <Expression xsi:type="SubscribeSubject" TypeArguments="sys:Double">
         <Name>GlobalTriggerFrequency</Name>
       </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="ExposureTime" Description="The duration of each individual exposure, in microseconds. To avoid trigger loss, values exceeding a period of 1 / frameRate - 1 millisecond will be capped." />
+      </Expression>
+      <Expression xsi:type="PropertySource" TypeArguments="aeon:SpinnakerCapture,sys:Double">
+        <MemberName>ExposureTime</MemberName>
+        <Value>INF</Value>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:CombineLatest" />
+      </Expression>
       <Expression xsi:type="scr:ExpressionTransform">
-        <scr:Expression>1e6 / it - 500</scr:Expression>
+        <scr:Expression>Math.Min(Item2, 1e6 / Item1 - 500)</scr:Expression>
       </Expression>
       <Expression xsi:type="PropertyMapping">
         <PropertyMappings>
@@ -56,17 +66,20 @@
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="8" Label="Source3" />
+      <Edge From="0" To="11" Label="Source3" />
       <Edge From="1" To="2" Label="Source1" />
-      <Edge From="2" To="8" Label="Source1" />
-      <Edge From="3" To="10" Label="Source2" />
+      <Edge From="2" To="11" Label="Source1" />
+      <Edge From="3" To="13" Label="Source2" />
       <Edge From="4" To="5" Label="Source1" />
-      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="5" To="8" Label="Source1" />
       <Edge From="6" To="7" Label="Source1" />
       <Edge From="7" To="8" Label="Source2" />
       <Edge From="8" To="9" Label="Source1" />
       <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="10" To="11" Label="Source2" />
+      <Edge From="11" To="12" Label="Source1" />
+      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="13" To="14" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR allows manually setting the exposure time of a Spinnaker video source, but introduces a guard to avoid trigger loss. If the manual value exceeds the maximum trigger period, it will be set to the maximum allowable interval given the trigger frequency.