### PR TITLE
Add operator for resolving the epoch data path

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.4.0</VersionPrefix>
-    <VersionSuffix>build230817</VersionSuffix>
+    <VersionSuffix>build230818</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/GetDataPath.cs
+++ b/src/Aeon.Acquisition/GetDataPath.cs
@@ -30,7 +30,10 @@ namespace Aeon.Acquisition
                 if (!(status.IsDirty || untrackedChanges) &&
                     repo.Tags.FirstOrDefault(r => r.Target == repo.Head.Tip) is Tag tag)
                 {
-                    return Path.Combine(DataPath, tag.FriendlyName);
+                    var name = tag.FriendlyName;
+                    var lastDot = name.LastIndexOf('.');
+                    if (lastDot >= 0) name = name.Substring(0, lastDot);
+                    return Path.Combine(DataPath, name);
                 }
                 else
                 {

--- a/src/Aeon.Acquisition/GetDataPath.cs
+++ b/src/Aeon.Acquisition/GetDataPath.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+using LibGit2Sharp;
+
+namespace Aeon.Acquisition
+{
+    [Combinator]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Retrieves the name of the data folder depending on the state of the specified repository.")]
+    public class GetDataPath
+    {
+        [Description("The relative or absolute path of the clean data directory.")]
+        [Editor("Bonsai.Design.FolderNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string DataPath { get; set; }
+
+        [Description("The relative or absolute path of the fallback data directory.")]
+        [Editor("Bonsai.Design.FolderNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string FallbackPath { get; set; }
+
+        public IObservable<string> Process(IObservable<IRepository> source)
+        {
+            return source.Select(repo =>
+            {
+                var status = repo.RetrieveStatus();
+                var untrackedChanges = status.Untracked.Any();
+                if (!(status.IsDirty || untrackedChanges) &&
+                    repo.Tags.FirstOrDefault(r => r.Target == repo.Head.Tip) is Tag tag)
+                {
+                    return Path.Combine(DataPath, tag.FriendlyName);
+                }
+                else
+                {
+                    var commitSha = repo.Head.Tip.Sha;
+                    var shortSha = commitSha.Substring(commitSha.Length - 7);
+                    var name = repo.Info.IsHeadDetached
+                        ? $"detached-{shortSha}"
+                        : $"{repo.Head.FriendlyName}-{shortSha}";
+                    return Path.Combine(FallbackPath, name);
+                }
+            });
+        }
+    }
+}

--- a/src/Aeon.Acquisition/RepositoryLogController.bonsai
+++ b/src/Aeon.Acquisition/RepositoryLogController.bonsai
@@ -1,11 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.3"
+<WorkflowBuilder Version="2.8.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
-                 xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
-                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
-                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
-                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>Specifies how to initialize logging paths from a git repo.</Description>
   <Workflow>
@@ -18,44 +14,15 @@
           <aeon:Path>..\..\</aeon:Path>
         </Combinator>
       </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="aeon:IsRepositoryClean" />
-      </Expression>
       <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Value" DisplayName="DataPath" Description="The relative or absolute path of the clean data directory." />
-      </Expression>
-      <Expression xsi:type="PropertySource" TypeArguments="io:GetFiles,sys:String">
-        <MemberName>Path</MemberName>
-        <Value>data</Value>
+        <Property Name="DataPath" />
+        <Property Name="FallbackPath" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:Take">
-          <rx:Count>1</rx:Count>
+        <Combinator xsi:type="aeon:GetDataPath">
+          <aeon:DataPath>data</aeon:DataPath>
+          <aeon:FallbackPath>devdata</aeon:FallbackPath>
         </Combinator>
-      </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Value" DisplayName="FallbackPath" Description="The relative or absolute path of the fallback data directory." />
-      </Expression>
-      <Expression xsi:type="PropertySource" TypeArguments="io:GetFiles,sys:String">
-        <MemberName>Path</MemberName>
-        <Value>devdata</Value>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:Take">
-          <rx:Count>1</rx:Count>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:Zip" />
-      </Expression>
-      <Expression xsi:type="scr:ExpressionTransform">
-        <scr:Expression>new(
-Item1 as Repository,
-Item2 ? Item3 : Item4 as BasePath)</scr:Expression>
-      </Expression>
-      <Expression xsi:type="Format">
-        <Format>{0}\{1}</Format>
-        <Selector>BasePath,Repository.Head.FriendlyName</Selector>
       </Expression>
       <Expression xsi:type="PropertyMapping">
         <PropertyMappings>
@@ -73,21 +40,12 @@ Item2 ? Item3 : Item4 as BasePath)</scr:Expression>
     </Nodes>
     <Edges>
       <Edge From="0" To="1" Label="Source1" />
-      <Edge From="1" To="2" Label="Source1" />
-      <Edge From="1" To="9" Label="Source1" />
-      <Edge From="2" To="9" Label="Source2" />
+      <Edge From="1" To="3" Label="Source1" />
+      <Edge From="2" To="3" Label="Source2" />
       <Edge From="3" To="4" Label="Source1" />
-      <Edge From="4" To="5" Label="Source1" />
-      <Edge From="5" To="9" Label="Source3" />
+      <Edge From="4" To="6" Label="Source1" />
+      <Edge From="5" To="6" Label="Source2" />
       <Edge From="6" To="7" Label="Source1" />
-      <Edge From="7" To="8" Label="Source1" />
-      <Edge From="8" To="9" Label="Source4" />
-      <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="11" Label="Source1" />
-      <Edge From="11" To="12" Label="Source1" />
-      <Edge From="12" To="14" Label="Source1" />
-      <Edge From="13" To="14" Label="Source2" />
-      <Edge From="14" To="15" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR introduces a new operator for resolving the epoch data path used by `RepositoryLogController`. The expected behavior is reproduced in the following flowchart. The tag name is assumed to end with a full [semver](https://semver.org/) string from which all characters after the last dot are removed.

```mermaid
flowchart LR
    A{Is Repo\nClean?} --> |no|B
    B(Detached\nHead?) --> |no|C
    B --> |yes|D
    C[fallback/branch-sha1]
    D[fallback/detached-sha1]
    A --> |yes|E
    E{Is Commit\nTagged?} --> |no|B
    E --> |yes|F
    F[data/tagname]
```

Fixes https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/291