### PR TITLE
Allow timestamped payload types as frame triggers

### DIFF
--- a/src/Aeon.Acquisition/PylonCapture.cs
+++ b/src/Aeon.Acquisition/PylonCapture.cs
@@ -11,7 +11,7 @@ namespace Aeon.Acquisition
     [Description("Configures and initializes a Pylon camera for triggered acquisition.")]
     public class PylonCapture : Bonsai.Pylon.PylonCapture
     {
-        public IObservable<Timestamped<VideoDataFrame>> Generate(IObservable<HarpMessage> source)
+        public IObservable<Timestamped<VideoDataFrame>> Generate<TPayload>(IObservable<Timestamped<TPayload>> source)
         {
             var frames = Generate();
             return frames
@@ -20,11 +20,7 @@ namespace Aeon.Acquisition
                     frame.GrabResult.ChunkData[PLChunkData.ChunkCounterValue].GetValue(),
                     frame.GrabResult.ChunkData[PLChunkData.ChunkTimestamp].GetValue()))
                 .FillGaps(frame => frame.ChunkData.FrameID, (previous, current) => (int)(current - previous - 1))
-                .Zip(source, (frame, trigger) =>
-                {
-                    var payload = trigger.GetTimestampedPayloadByte();
-                    return Timestamped.Create(frame, payload.Seconds);
-                })
+                .Zip(source, (frame, payload) => Timestamped.Create(frame, payload.Seconds))
                 .Where(timestamped => timestamped.Value != null);
         }
     }

--- a/src/Aeon.Acquisition/PylonVideoSource.bonsai
+++ b/src/Aeon.Acquisition/PylonVideoSource.bonsai
@@ -15,7 +15,7 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="TriggerSource" Description="The PWM trigger source used to drive the camera." />
       </Expression>
-      <Expression xsi:type="SubscribeSubject" TypeArguments="harp:HarpMessage">
+      <Expression xsi:type="SubscribeSubject">
         <Name>GlobalTrigger</Name>
       </Expression>
       <Expression xsi:type="Combinator">

--- a/src/Aeon.Acquisition/SpinnakerVideoSource.bonsai
+++ b/src/Aeon.Acquisition/SpinnakerVideoSource.bonsai
@@ -18,7 +18,7 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="TriggerSource" Description="The PWM trigger source used to drive the camera." />
       </Expression>
-      <Expression xsi:type="SubscribeSubject" TypeArguments="harp:HarpMessage">
+      <Expression xsi:type="SubscribeSubject">
         <Name>GlobalTrigger</Name>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">

--- a/src/Aeon.Acquisition/VideoController.bonsai
+++ b/src/Aeon.Acquisition/VideoController.bonsai
@@ -81,7 +81,7 @@
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
       <Expression xsi:type="p1:Parse">
-        <harp:Register xsi:type="p1:PwmRiseEvent" />
+        <harp:Register xsi:type="p1:TimestampedPwmRiseEvent" />
       </Expression>
       <Expression xsi:type="rx:Condition">
         <Name>Pwm1</Name>
@@ -89,6 +89,9 @@
           <Nodes>
             <Expression xsi:type="WorkflowInput">
               <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value</Selector>
             </Expression>
             <Expression xsi:type="HasFlag">
               <Operand xsi:type="WorkflowProperty" TypeArguments="p1:PwmChannels">
@@ -100,6 +103,7 @@
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
             <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
@@ -113,6 +117,9 @@
             <Expression xsi:type="WorkflowInput">
               <Name>Source1</Name>
             </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Value</Selector>
+            </Expression>
             <Expression xsi:type="HasFlag">
               <Operand xsi:type="WorkflowProperty" TypeArguments="p1:PwmChannels">
                 <Value>Pwm2</Value>
@@ -123,6 +130,7 @@
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
             <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="3" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Aeon.Acquisition/VideoSource.bonsai
+++ b/src/Aeon.Acquisition/VideoSource.bonsai
@@ -18,7 +18,7 @@
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="TriggerSource" Description="The PWM trigger source used to drive the camera." />
       </Expression>
-      <Expression xsi:type="SubscribeSubject" TypeArguments="harp:HarpMessage">
+      <Expression xsi:type="SubscribeSubject">
         <Name>GlobalTrigger</Name>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">


### PR DESCRIPTION
This PR replaces the type signature for the video capture sources to accept any parsed timestamped payload type. This avoids having to reparse messages and also provides flexibility as to the type of the trigger payload.