### PR TITLE
Add operators for tracking and logging pose tracking streams

### DIFF
--- a/src/Aeon.Acquisition/CreatePoseTrackingMetadata.cs
+++ b/src/Aeon.Acquisition/CreatePoseTrackingMetadata.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+
+namespace Aeon.Acquisition
+{
+    [Description("Initializes a pose tracking metadata object from the specified model path.")]
+    public class CreatePoseTrackingMetadata : Source<PoseTrackingMetadata>
+    {
+        [Description("The relative or absolute path of the folder containing the pretrained pose tracking model.")]
+        [Editor("Bonsai.Design.FolderNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        public string ModelPath { get; set; }
+
+        public override IObservable<PoseTrackingMetadata> Generate()
+        {
+            return Observable.Defer(() => Observable.Return(new PoseTrackingMetadata(ModelPath)));
+        }
+
+        public IObservable<PoseTrackingMetadata> Generate(IObservable<string> source)
+        {
+            return source.Select(prefix => new PoseTrackingMetadata(ModelPath, prefix));
+        }
+    }
+
+    public class PoseTrackingMetadata
+    {
+        internal PoseTrackingMetadata(string modelPath, string prefix = default)
+        {
+            if (string.IsNullOrEmpty(modelPath))
+            {
+                throw new ArgumentNullException(nameof(modelPath));
+            }
+
+            var fullModelPath = prefix != null ? Path.Combine(prefix, modelPath) : modelPath;
+            var directoryInfo = new DirectoryInfo(fullModelPath);
+            if (!directoryInfo.Exists)
+            {
+                throw new ArgumentException("The specified model path does not exist.", nameof(modelPath));
+            }
+
+            var pbFiles = directoryInfo.GetFiles("*.pb");
+            if (pbFiles.Length != 1)
+            {
+                throw new ArgumentException(
+                    "The specified model path does not contain an exported graph; or has more than one pb file.",
+                    nameof(modelPath));
+            }
+
+            var jsonConfigFiles = directoryInfo.GetFiles("*.json");
+            if (jsonConfigFiles.Length != 1)
+            {
+                throw new ArgumentException(
+                    "The specified model path does not contain a trained config file; or has more than one JSON file.",
+                    nameof(modelPath));
+            }
+
+            if (Path.IsPathRooted(modelPath))
+            {
+                var separatorIndex = modelPath.IndexOf(Path.VolumeSeparatorChar);
+                if (separatorIndex >= 0) modelPath = modelPath.Substring(separatorIndex + 1);
+            }
+
+            ModelFileName = pbFiles[0].FullName;
+            TrainingConfig = jsonConfigFiles[0].FullName;
+            LogName = modelPath
+                .Trim(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .Replace(Path.DirectorySeparatorChar, '_')
+                .Replace(Path.AltDirectorySeparatorChar, '_');
+        }
+
+        public string ModelFileName { get; }
+
+        public string TrainingConfig { get; }
+
+        public string LogName { get; }
+
+        public override string ToString()
+        {
+            return $"{nameof(PoseTrackingMetadata)}: {LogName}";
+        }
+    }
+}

--- a/src/Aeon.Acquisition/FormatPose.cs
+++ b/src/Aeon.Acquisition/FormatPose.cs
@@ -23,17 +23,20 @@ namespace Aeon.Acquisition
         {
             return source.Select(value =>
             {
+                var i = 0;
                 var pose = value.Item1;
                 var timestamp = value.Item2;
-                var data = new float[2 + pose.Count * 3];
-                data[0] = IdentityIndex == null ? pose.IdentityIndex : (float)IdentityIndex;
-                data[1] = pose.Confidence;
-                int i = 1;
+                var data = new float[5 + pose.Count * 3];
+                data[i++] = IdentityIndex.GetValueOrDefault(pose.IdentityIndex);
+                data[i++] = pose.Confidence;
+                data[i++] = pose.Centroid.Position.X;
+                data[i++] = pose.Centroid.Position.Y;
+                data[i++] = pose.Centroid.Confidence;
                 foreach (var bp in pose)
                 {
-                    data[++i] = bp.Position.X;
-                    data[++i] = bp.Position.Y;
-                    data[++i] = bp.Confidence;
+                    data[i++] = bp.Position.X;
+                    data[i++] = bp.Position.Y;
+                    data[i++] = bp.Confidence;
                 }
                 return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
             });
@@ -47,15 +50,20 @@ namespace Aeon.Acquisition
                 var timestamp = value.Item2;
                 return poseCollection.Select((pose, index) =>
                 {
-                    var data = new float[2 + pose.Count * 3];
-                    data[0] = IdentityIndex == null ? pose.IdentityIndex : (float)IdentityIndex;
-                    data[1] = pose.Confidence;
-                    int i = 1;
+                    int i = 0;
+                    var data = new float[5 + pose.Count * 3];
+                    data[i++] = IdentityIndex.HasValue
+                        ? IdentityIndex.GetValueOrDefault() + index
+                        : pose.IdentityIndex;
+                    data[i++] = pose.Confidence;
+                    data[i++] = pose.Centroid.Position.X;
+                    data[i++] = pose.Centroid.Position.Y;
+                    data[i++] = pose.Centroid.Confidence;
                     foreach (var bp in pose)
                     {
-                        data[++i] = bp.Position.X;
-                        data[++i] = bp.Position.Y;
-                        data[++i] = bp.Confidence;
+                        data[i++] = bp.Position.X;
+                        data[i++] = bp.Position.Y;
+                        data[i++] = bp.Confidence;
                     }
                     return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
                 });
@@ -66,17 +74,20 @@ namespace Aeon.Acquisition
         {
             return source.Select(value =>
             {
+                int i = 0;
                 var pose = value.Item1;
                 var timestamp = value.Item2;
-                var data = new float[2 + pose.Count * 3];
-                data[0] = IdentityIndex == null ? -1f : (float)IdentityIndex;
-                data[1] = float.NaN;
-                int i = 1;
+                var data = new float[5 + pose.Count * 3];
+                data[i++] = IdentityIndex.GetValueOrDefault(-1);
+                data[i++] = float.NaN;
+                data[i++] = pose.Centroid.Position.X;
+                data[i++] = pose.Centroid.Position.Y;
+                data[i++] = pose.Centroid.Confidence;
                 foreach (var bp in pose)
                 {
-                    data[++i] = bp.Position.X;
-                    data[++i] = bp.Position.Y;
-                    data[++i] = bp.Confidence;
+                    data[i++] = bp.Position.X;
+                    data[i++] = bp.Position.Y;
+                    data[i++] = bp.Confidence;
                 }
                 return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
             });
@@ -90,15 +101,18 @@ namespace Aeon.Acquisition
                 var timestamp = value.Item2;
                 return poseCollection.Select((pose, index) =>
                 {
-                    var data = new float[2 + pose.Count * 3];
-                    data[0] = IdentityIndex == null ? index : (float)IdentityIndex;
-                    data[1] = float.NaN;
-                    int i = 1;
+                    int i = 0;
+                    var data = new float[5 + pose.Count * 3];
+                    data[i++] = IdentityIndex.GetValueOrDefault() + index;
+                    data[i++] = float.NaN;
+                    data[i++] = pose.Centroid.Position.X;
+                    data[i++] = pose.Centroid.Position.Y;
+                    data[i++] = pose.Centroid.Confidence;
                     foreach (var bp in pose)
                     {
-                        data[++i] = bp.Position.X;
-                        data[++i] = bp.Position.Y;
-                        data[++i] = bp.Confidence;
+                        data[i++] = bp.Position.X;
+                        data[i++] = bp.Position.Y;
+                        data[i++] = bp.Confidence;
                     }
                     return HarpMessage.FromSingle(Address, timestamp, MessageType.Event, data);
                 });

--- a/src/Aeon.Acquisition/FormatPose.cs
+++ b/src/Aeon.Acquisition/FormatPose.cs
@@ -19,13 +19,13 @@ namespace Aeon.Acquisition
         [Description("Optional value to override or set the identity index returned by the source pose.")]
         public int? IdentityIndex { get; set; }
 
-        public IObservable<HarpMessage> Process(IObservable<Tuple<PoseIdentity, double>> source)
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PoseIdentity>> source)
         {
-            return source.Select(value =>
+            return source.Select(payload =>
             {
                 var i = 0;
-                var pose = value.Item1;
-                var timestamp = value.Item2;
+                var pose = payload.Value;
+                var timestamp = payload.Seconds;
                 var data = new float[5 + pose.Count * 3];
                 data[i++] = IdentityIndex.GetValueOrDefault(pose.IdentityIndex);
                 data[i++] = pose.Confidence;
@@ -42,12 +42,12 @@ namespace Aeon.Acquisition
             });
         }
 
-        public IObservable<HarpMessage> Process(IObservable<Tuple<PoseIdentityCollection, double>> source)
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PoseIdentityCollection>> source)
         {
-            return source.SelectMany(value =>
+            return source.SelectMany(payload =>
             {
-                var poseCollection = value.Item1;
-                var timestamp = value.Item2;
+                var poseCollection = payload.Value;
+                var timestamp = payload.Seconds;
                 return poseCollection.Select((pose, index) =>
                 {
                     int i = 0;
@@ -70,13 +70,13 @@ namespace Aeon.Acquisition
             });
         }
 
-        public IObservable<HarpMessage> Process(IObservable<Tuple<Pose, double>> source)
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<Pose>> source)
         {
-            return source.Select(value =>
+            return source.Select(payload =>
             {
                 int i = 0;
-                var pose = value.Item1;
-                var timestamp = value.Item2;
+                var pose = payload.Value;
+                var timestamp = payload.Seconds;
                 var data = new float[5 + pose.Count * 3];
                 data[i++] = IdentityIndex.GetValueOrDefault(-1);
                 data[i++] = float.NaN;
@@ -93,12 +93,12 @@ namespace Aeon.Acquisition
             });
         }
 
-        public IObservable<HarpMessage> Process(IObservable<Tuple<PoseCollection, double>> source)
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<PoseCollection>> source)
         {
-            return source.SelectMany(value =>
+            return source.SelectMany(payload =>
             {
-                var poseCollection = value.Item1;
-                var timestamp = value.Item2;
+                var poseCollection = payload.Value;
+                var timestamp = payload.Seconds;
                 return poseCollection.Select((pose, index) =>
                 {
                     int i = 0;

--- a/src/Aeon.Acquisition/LogPoseTracking.bonsai
+++ b/src/Aeon.Acquisition/LogPoseTracking.bonsai
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Description>Chunks and logs a timestamped pose tracking stream into the base data log.</Description>
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Address" />
+        <Property Name="IdentityIndex" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon:FormatPose">
+          <aeon:Address>255</aeon:Address>
+          <aeon:IdentityIndex xsi:nil="true" />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="LogName" />
+      </Expression>
+      <Expression xsi:type="PropertySource" TypeArguments="WorkflowProperty(sys:String),sys:String">
+        <MemberName>LogName</MemberName>
+        <Value>PoseTrackingData</Value>
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>PoseTrackingMetadata</Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Format">
+        <Format>{0}_{1}</Format>
+        <Selector>Item1,Item2.LogName</Selector>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="LogName" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarp.bonsai">
+        <Heartbeats xsi:nil="true" />
+        <ClosingDuration xsi:nil="true" />
+        <LogName>PoseTrackingData</LogName>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="2" Label="Source1" />
+      <Edge From="1" To="2" Label="Source2" />
+      <Edge From="2" To="10" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="6" Label="Source1" />
+      <Edge From="5" To="6" Label="Source2" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="9" To="10" Label="Source2" />
+      <Edge From="10" To="11" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Aeon.Acquisition/PathController.bonsai
+++ b/src/Aeon.Acquisition/PathController.bonsai
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Description>Creates a named subject storing a specified path used for search.</Description>
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="Path" />
+      </Expression>
+      <Expression xsi:type="PropertySource" TypeArguments="io:GetFiles,sys:String">
+        <MemberName>Path</MemberName>
+        <Value>data</Value>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="PathName" Description="The name of the output sequence containing the specified search path." />
+      </Expression>
+      <Expression xsi:type="rx:AsyncSubject">
+        <Name>PathName</Name>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="2" To="4" Label="Source1" />
+      <Edge From="3" To="4" Label="Source2" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Aeon.Acquisition/PoseTracking.bonsai
+++ b/src/Aeon.Acquisition/PoseTracking.bonsai
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
+                 xmlns:sleap="clr-namespace:Bonsai.Sleap;assembly=Bonsai.Sleap"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Description>Extracts pose tracking information from an image sequence given the specified inference model.</Description>
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="WorkflowInput">
+        <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Value.Image</Selector>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Value" DisplayName="ModelPath" Description="Specifies the path to the folder containing the pretrained SLEAP model." />
+      </Expression>
+      <Expression xsi:type="PropertySource" TypeArguments="io:EnumerateFiles,sys:String">
+        <MemberName>Path</MemberName>
+        <Value>.</Value>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="scr:ExpressionTransform">
+        <scr:Expression>new(
+it + "/frozen_graph.pb" as ModelFileName,
+it + "/confmap_config.json" as TrainingConfig)</scr:Expression>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="PoseTrackingMetadata" Description="The name of the subject storing model metadata." />
+      </Expression>
+      <Expression xsi:type="rx:AsyncSubject">
+        <Name>PoseTrackingMetadata</Name>
+      </Expression>
+      <Expression xsi:type="PropertyMapping">
+        <PropertyMappings>
+          <Property Name="ModelFileName" Selector="ModelFileName" />
+          <Property Name="TrainingConfig" Selector="TrainingConfig" />
+        </PropertyMappings>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="CentroidMinConfidence" />
+        <Property Name="IdentityMinConfidence" />
+        <Property Name="PartMinConfidence" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="sleap:PredictPoseIdentities">
+          <sleap:CentroidMinConfidence xsi:nil="true" />
+          <sleap:IdentityMinConfidence xsi:nil="true" />
+          <sleap:PartMinConfidence xsi:nil="true" />
+          <sleap:ScaleFactor xsi:nil="true" />
+          <sleap:ColorConversion xsi:nil="true" />
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="MemberSelector">
+        <Selector>Seconds</Selector>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Zip" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:CreateTimestamped" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="PoseTrackingEvents" Description="The name of the output sequence containing all pose tracking data." />
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject">
+        <Name>PoseTrackingEvents</Name>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="0" To="11" Label="Source1" />
+      <Edge From="1" To="10" Label="Source1" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="4" Label="Source1" />
+      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="5" To="7" Label="Source1" />
+      <Edge From="6" To="7" Label="Source2" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="10" Label="Source2" />
+      <Edge From="9" To="10" Label="Source3" />
+      <Edge From="10" To="12" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
+      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="13" To="15" Label="Source1" />
+      <Edge From="14" To="15" Label="Source2" />
+      <Edge From="15" To="16" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Aeon.Acquisition/PoseTracking.bonsai
+++ b/src/Aeon.Acquisition/PoseTracking.bonsai
@@ -1,10 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <WorkflowBuilder Version="2.8.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xmlns:io="clr-namespace:Bonsai.IO;assembly=Bonsai.System"
-                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
-                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:sleap="clr-namespace:Bonsai.Sleap;assembly=Bonsai.Sleap"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns="https://bonsai-rx.org/2018/workflow">
@@ -18,21 +16,18 @@
         <Selector>Value.Image</Selector>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Value" DisplayName="ModelPath" Description="Specifies the path to the folder containing the pretrained SLEAP model." />
+        <Property Name="Name" DisplayName="PathPrefix" Description="The optional root folder containing all pretrained models." />
       </Expression>
-      <Expression xsi:type="PropertySource" TypeArguments="io:EnumerateFiles,sys:String">
-        <MemberName>Path</MemberName>
-        <Value>.</Value>
+      <Expression xsi:type="SubscribeSubject">
+        <Name />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="ModelPath" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:Take">
-          <rx:Count>1</rx:Count>
+        <Combinator xsi:type="aeon:CreatePoseTrackingMetadata">
+          <aeon:ModelPath />
         </Combinator>
-      </Expression>
-      <Expression xsi:type="scr:ExpressionTransform">
-        <scr:Expression>new(
-it + "/frozen_graph.pb" as ModelFileName,
-it + "/confmap_config.json" as TrainingConfig)</scr:Expression>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="PoseTrackingMetadata" Description="The name of the subject storing model metadata." />
@@ -82,8 +77,8 @@ it + "/confmap_config.json" as TrainingConfig)</scr:Expression>
       <Edge From="0" To="11" Label="Source1" />
       <Edge From="1" To="10" Label="Source1" />
       <Edge From="2" To="3" Label="Source1" />
-      <Edge From="3" To="4" Label="Source1" />
-      <Edge From="4" To="5" Label="Source1" />
+      <Edge From="3" To="5" Label="Source1" />
+      <Edge From="4" To="5" Label="Source2" />
       <Edge From="5" To="7" Label="Source1" />
       <Edge From="6" To="7" Label="Source2" />
       <Edge From="7" To="8" Label="Source1" />


### PR DESCRIPTION
This PR adds a pose identity tracking operator over timestamped video sources. It includes simple model metadata management to access and record pretrained model paths and a logging operator that formats the names of pose identity streams according to the format specified in https://github.com/SainsburyWellcomeCentre/aeon_mecha/pull/206.

Fixes #135 