### PR TITLE
Add support for different clock synchronizers

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.4.0</VersionPrefix>
-    <VersionSuffix>build230821</VersionSuffix>
+    <VersionSuffix>build230822</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>
@@ -19,7 +19,9 @@
     <PackageReference Include="Bonsai.Audio" Version="2.8.0" />
     <PackageReference Include="Bonsai.Harp" Version="3.5.0" />
     <PackageReference Include="Harp.CameraControllerGen2" Version="0.1.0" />
+    <PackageReference Include="Harp.ClockSynchronizer" Version="0.1.0" />
     <PackageReference Include="Harp.OutputExpander" Version="0.2.0-build230803" />
+    <PackageReference Include="Harp.TimestampGeneratorGen3" Version="0.1.0" />
     <PackageReference Include="Bonsai.Osc" Version="2.7.0" />
     <PackageReference Include="Bonsai.Pylon" Version="0.3.0" />
     <PackageReference Include="Bonsai.Sleap" Version="0.2.0" />
@@ -28,7 +30,6 @@
     <PackageReference Include="Bonsai.System" Version="2.8.0" />
     <PackageReference Include="Bonsai.Scripting.Expressions" Version="2.8.0" />
     <PackageReference Include="Bonsai.ZeroMQ" Version="0.2.0" />
-    <PackageReference Include="Harp.Synchronizer" Version="0.1.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.25.4" />
     <PackageReference Include="Bonsai.Vision" Version="2.8.0" />
     <PackageReference Include="MathNet.Numerics" Version="4.5.1" />

--- a/src/Aeon.Acquisition/ClockSynchronizer.bonsai
+++ b/src/Aeon.Acquisition/ClockSynchronizer.bonsai
@@ -4,6 +4,7 @@
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:p1="clr-namespace:Harp.ClockSynchronizer;assembly=Harp.ClockSynchronizer"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>Provides functionality for synchronizing all arena Harp devices and setting the UTC time reference.</Description>
   <Workflow>
@@ -18,7 +19,7 @@
         <Property Name="PortName" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="harp:Device">
+        <Combinator xsi:type="p1:Device">
           <harp:OperationMode>Active</harp:OperationMode>
           <harp:OperationLed>On</harp:OperationLed>
           <harp:DumpRegisters>true</harp:DumpRegisters>

--- a/src/Aeon.Acquisition/Synchronizer.cs
+++ b/src/Aeon.Acquisition/Synchronizer.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Aeon.Acquisition
+{
+    [Obsolete]
+    internal class Synchronizer
+    {
+    }
+}

--- a/src/Aeon.Acquisition/TimestampGenerator.bonsai
+++ b/src/Aeon.Acquisition/TimestampGenerator.bonsai
@@ -4,8 +4,9 @@
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:p1="clr-namespace:Harp.TimestampGeneratorGen3;assembly=Harp.TimestampGeneratorGen3"
                  xmlns="https://bonsai-rx.org/2018/workflow">
-  <Description>Provides functionality for synchronizing all arena Harp devices and setting the UTC time reference.</Description>
+  <Description>Provides support for uninterruptible synchronization of all arena Harp devices and setting the UTC time reference.</Description>
   <Workflow>
     <Nodes>
       <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Object">
@@ -18,7 +19,7 @@
         <Property Name="PortName" />
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="harp:Device">
+        <Combinator xsi:type="p1:Device">
           <harp:OperationMode>Active</harp:OperationMode>
           <harp:OperationLed>On</harp:OperationLed>
           <harp:DumpRegisters>true</harp:DumpRegisters>


### PR DESCRIPTION
This PR introduces explicit support for using different clock synchronizer devices. There are currently two versions of clock synchronization devices in the Harp ecosystem.

The [ClockSynchronizer](https://github.com/harp-tech/device.clocksynchronizer) is the original device that allows coordinating up to 6 Harp devices but has no backup power supply.

The [TimestampGenerator](https://github.com/harp-tech/device.timestampgeneratorgen3) on the other hand comes with a chargeable battery that ensures that the clock can persist even in the presence of unexpected power failures.

The original `Synchronizer` node accepted devices of all kinds but we have now deprecated it in order to ensure that a valid clock generator is used for device synchronization.