### PR TITLE
Add database package core operators

### DIFF
--- a/src/Aeon.Database/Aeon.Database.csproj
+++ b/src/Aeon.Database/Aeon.Database.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <Title>Project Aeon - Database</Title>
+    <Description>Provides querying and schema functionality for Project Aeon databases.</Description>
+    <PackageTags>Bonsai Rx Project Aeon Database</PackageTags>
+    <TargetFramework>net472</TargetFramework>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionSuffix>build230831</VersionSuffix>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="**\*.bonsai" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MySqlConnector" Version="2.2.7" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Aeon.Acquisition\Aeon.Acquisition.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aeon.Database/CreateConnection.cs
+++ b/src/Aeon.Database/CreateConnection.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using Bonsai;
+using MySqlConnector;
+
+namespace Aeon.Database
+{
+    [DefaultProperty(nameof(ConnectionString))]
+    [Description("Creates a connection to the MySQL server using the specified connection string.")]
+    public class CreateConnection : Source<MySqlConnection>
+    {
+        [Editor("Bonsai.Design.RichTextEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("Specifies the parameters used to establish a connection to the MySQL server.")]
+        public string ConnectionString { get; set; }
+
+        public override IObservable<MySqlConnection> Generate()
+        {
+            return Observable.Defer(async () =>
+            {
+                var connection = new MySqlConnection(ConnectionString);
+                await connection.OpenAsync();
+                return Observable.Return(connection);
+            });
+        }
+    }
+}

--- a/src/Aeon.Database/EnumerateColony.cs
+++ b/src/Aeon.Database/EnumerateColony.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+using MySqlConnector;
+
+namespace Aeon.Database
+{
+    [Description("Enumerates all records in the colony table for each MySQL connection in the sequence.")]
+    public class EnumerateColony : Combinator<MySqlConnection, ColonyRecord>
+    {
+        public override IObservable<ColonyRecord> Process(IObservable<MySqlConnection> source)
+        {
+            return source.SelectMany(connection => ObservableDatabase.Query<ColonyRecord>(
+                "SELECT * FROM `#colony`;",
+                connection));
+        }
+    }
+
+    public class ColonyRecord
+    {
+        public string Subject { get; set; }
+
+        public float? ReferenceWeight { get; set; }
+
+        public SubjectSex Sex { get; set; }
+
+        public DateTime? SubjectBirthDate { get; set; }
+
+        public string Note { get; set; }
+
+        public override string ToString()
+        {
+            return $"({Subject}, wt: {ReferenceWeight}, sex: {Sex}, dob: {SubjectBirthDate}, {Note})";
+        }
+    }
+
+    public enum SubjectSex
+    {
+        Male = 'M',
+        Female = 'F',
+        Unspecified = 'U'
+    }
+}

--- a/src/Aeon.Database/ExecuteQuery.cs
+++ b/src/Aeon.Database/ExecuteQuery.cs
@@ -17,12 +17,7 @@ namespace Aeon.Database
 
         public override IObservable<MySqlDataReader> Process(IObservable<MySqlConnection> source)
         {
-            return source.SelectMany(async (connection, cancellationToken) =>
-            {
-                using var command = new MySqlCommand(QueryString, connection);
-                var reader = await command.ExecuteReaderAsync(cancellationToken);
-                return reader;
-            });
+            return source.SelectMany(connection => ObservableDatabase.Query(QueryString, connection));
         }
     }
 }

--- a/src/Aeon.Database/ExecuteQuery.cs
+++ b/src/Aeon.Database/ExecuteQuery.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+using MySqlConnector;
+
+namespace Aeon.Database
+{
+    [DefaultProperty(nameof(QueryString))]
+    [Description("Runs the specified SQL query against each MySQL connection in the sequence.")]
+    public class ExecuteQuery : Combinator<MySqlConnection, MySqlDataReader>
+    {
+        [Editor("Bonsai.Design.RichTextEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
+        [Description("Specifies the full SQL query to run against the MySQL connection.")]
+        public string QueryString { get; set; }
+
+        public override IObservable<MySqlDataReader> Process(IObservable<MySqlConnection> source)
+        {
+            return source.SelectMany(async (connection, cancellationToken) =>
+            {
+                using var command = new MySqlCommand(QueryString, connection);
+                var reader = await command.ExecuteReaderAsync(cancellationToken);
+                return reader;
+            });
+        }
+    }
+}

--- a/src/Aeon.Database/ObservableDatabase.cs
+++ b/src/Aeon.Database/ObservableDatabase.cs
@@ -38,5 +38,80 @@ namespace Aeon.Database
                 }
             });
         }
+
+        public static bool GetBooleanOrDefault(this MySqlDataReader reader, int ordinal, bool defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetBoolean(ordinal);
+        }
+
+        public static char GetCharOrDefault(this MySqlDataReader reader, int ordinal, char defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetChar(ordinal);
+        }
+
+        public static sbyte GetSByteOrDefault(this MySqlDataReader reader, int ordinal, sbyte defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetSByte(ordinal);
+        }
+
+        public static byte GetByteOrDefault(this MySqlDataReader reader, int ordinal, byte defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetByte(ordinal);
+        }
+
+        public static short GetInt16OrDefault(this MySqlDataReader reader, int ordinal, short defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetInt16(ordinal);
+        }
+
+        public static ushort GetUInt16OrDefault(this MySqlDataReader reader, int ordinal, ushort defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetUInt16(ordinal);
+        }
+
+        public static int GetInt32OrDefault(this MySqlDataReader reader, int ordinal, int defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetInt32(ordinal);
+        }
+
+        public static uint GetUInt32OrDefault(this MySqlDataReader reader, int ordinal, uint defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetUInt32(ordinal);
+        }
+
+        public static long GetInt64OrDefault(this MySqlDataReader reader, int ordinal, long defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetInt64(ordinal);
+        }
+
+        public static ulong GetUInt64OrDefault(this MySqlDataReader reader, int ordinal, ulong defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetUInt64(ordinal);
+        }
+
+        public static float GetFloatOrDefault(this MySqlDataReader reader, int ordinal, float defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetFloat(ordinal);
+        }
+
+        public static double GetDoubleOrDefault(this MySqlDataReader reader, int ordinal, double defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetDouble(ordinal);
+        }
+
+        public static decimal GetDecimalOrDefault(this MySqlDataReader reader, int ordinal, decimal defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetDecimal(ordinal);
+        }
+
+        public static DateTime GetDateTimeOrDefault(this MySqlDataReader reader, int ordinal, DateTime defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetDateTime(ordinal);
+        }
+
+        public static string GetStringOrDefault(this MySqlDataReader reader, int ordinal, string defaultValue = default)
+        {
+            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetString(ordinal);
+        }
     }
 }

--- a/src/Aeon.Database/ObservableDatabase.cs
+++ b/src/Aeon.Database/ObservableDatabase.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Reactive.Linq;
+using MySqlConnector;
+
+namespace Aeon.Database
+{
+    static class ObservableDatabase
+    {
+        public static IObservable<MySqlDataReader> Query(string queryString, MySqlConnection connection)
+        {
+            return Query(queryString, connection, reader => reader);
+        }
+
+        public static IObservable<TResult> Query<TResult>(
+            string queryString,
+            MySqlConnection connection,
+            Func<MySqlDataReader, TResult> selector)
+        {
+            return Query(queryString, connection, reader => { }, selector);
+        }
+
+        public static IObservable<TResult> Query<TResult>(
+            string queryString,
+            MySqlConnection connection,
+            Action<MySqlDataReader> validator,
+            Func<MySqlDataReader, TResult> selector)
+        {
+            return Observable.Create<TResult>(async (observer, cancellationToken) =>
+            {
+                using var command = new MySqlCommand(queryString, connection);
+                using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+                validator(reader);
+                while (await reader.ReadAsync(cancellationToken))
+                {
+                    var result = selector(reader);
+                    observer.OnNext(result);
+                }
+            });
+        }
+    }
+}

--- a/src/Aeon.Database/ObservableDatabase.cs
+++ b/src/Aeon.Database/ObservableDatabase.cs
@@ -11,6 +11,15 @@ namespace Aeon.Database
             return Query(queryString, connection, reader => reader);
         }
 
+        public static IObservable<TResult> Query<TResult>(string queryString, MySqlConnection connection)
+        {
+            return Query(
+                queryString,
+                connection,
+                RecordReader<TResult>.Instance.Validate,
+                RecordReader<TResult>.Instance.Select);
+        }
+
         public static IObservable<TResult> Query<TResult>(
             string queryString,
             MySqlConnection connection,

--- a/src/Aeon.Database/ObservableDatabase.cs
+++ b/src/Aeon.Database/ObservableDatabase.cs
@@ -48,79 +48,79 @@ namespace Aeon.Database
             });
         }
 
-        public static bool GetBooleanOrDefault(this MySqlDataReader reader, int ordinal, bool defaultValue = default)
+        public static bool? BooleanField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetBoolean(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetBoolean(ordinal);
         }
 
-        public static char GetCharOrDefault(this MySqlDataReader reader, int ordinal, char defaultValue = default)
+        public static char? CharField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetChar(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetChar(ordinal);
         }
 
-        public static sbyte GetSByteOrDefault(this MySqlDataReader reader, int ordinal, sbyte defaultValue = default)
+        public static sbyte? SByteField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetSByte(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetSByte(ordinal);
         }
 
-        public static byte GetByteOrDefault(this MySqlDataReader reader, int ordinal, byte defaultValue = default)
+        public static byte? ByteField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetByte(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetByte(ordinal);
         }
 
-        public static short GetInt16OrDefault(this MySqlDataReader reader, int ordinal, short defaultValue = default)
+        public static short? Int16Field(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetInt16(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetInt16(ordinal);
         }
 
-        public static ushort GetUInt16OrDefault(this MySqlDataReader reader, int ordinal, ushort defaultValue = default)
+        public static ushort? UInt16Field(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetUInt16(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetUInt16(ordinal);
         }
 
-        public static int GetInt32OrDefault(this MySqlDataReader reader, int ordinal, int defaultValue = default)
+        public static int? Int32Field(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetInt32(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetInt32(ordinal);
         }
 
-        public static uint GetUInt32OrDefault(this MySqlDataReader reader, int ordinal, uint defaultValue = default)
+        public static uint? UInt32Field(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetUInt32(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetUInt32(ordinal);
         }
 
-        public static long GetInt64OrDefault(this MySqlDataReader reader, int ordinal, long defaultValue = default)
+        public static long? Int64Field(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetInt64(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetInt64(ordinal);
         }
 
-        public static ulong GetUInt64OrDefault(this MySqlDataReader reader, int ordinal, ulong defaultValue = default)
+        public static ulong? UInt64Field(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetUInt64(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetUInt64(ordinal);
         }
 
-        public static float GetFloatOrDefault(this MySqlDataReader reader, int ordinal, float defaultValue = default)
+        public static float? FloatField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetFloat(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetFloat(ordinal);
         }
 
-        public static double GetDoubleOrDefault(this MySqlDataReader reader, int ordinal, double defaultValue = default)
+        public static double? DoubleField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetDouble(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetDouble(ordinal);
         }
 
-        public static decimal GetDecimalOrDefault(this MySqlDataReader reader, int ordinal, decimal defaultValue = default)
+        public static decimal? DecimalField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetDecimal(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetDecimal(ordinal);
         }
 
-        public static DateTime GetDateTimeOrDefault(this MySqlDataReader reader, int ordinal, DateTime defaultValue = default)
+        public static DateTime? DateTimeField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetDateTime(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetDateTime(ordinal);
         }
 
-        public static string GetStringOrDefault(this MySqlDataReader reader, int ordinal, string defaultValue = default)
+        public static string StringField(this MySqlDataReader reader, int ordinal)
         {
-            return reader.IsDBNull(ordinal) ? defaultValue : reader.GetString(ordinal);
+            return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
         }
     }
 }

--- a/src/Aeon.Database/Properties/AssemblyInfo.cs
+++ b/src/Aeon.Database/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿using Bonsai;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: XmlNamespacePrefix("clr-namespace:Aeon.Database", "aeondb")]

--- a/src/Aeon.Database/Properties/launchSettings.json
+++ b/src/Aeon.Database/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "Bonsai": {
+      "commandName": "Executable",
+      "executablePath": "$(registry:HKEY_CURRENT_USER\\Software\\Bonsai Foundation\\Bonsai@InstallDir)Bonsai.exe",
+      "commandLineArgs": "--lib:$(TargetDir).",
+      "nativeDebugging": true
+    }
+  }
+}

--- a/src/Aeon.Database/RecordReader.cs
+++ b/src/Aeon.Database/RecordReader.cs
@@ -1,0 +1,209 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq.Expressions;
+using System.Reflection;
+using MySqlConnector;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Aeon.Database
+{
+    class RecordReader<T>
+    {
+        private static readonly PropertyInfo[] Members = typeof(T).GetProperties();
+        public static readonly RecordReader<T> Instance = new();
+
+        private RecordReader()
+        {
+            Validate = CreateSchemaValidator();
+            Select = CreateSelector();
+        }
+
+
+        public Action<MySqlDataReader> Validate { get; }
+
+        public Func<MySqlDataReader, T> Select { get; }
+
+        private static Action<MySqlDataReader> CreateSchemaValidator()
+        {
+            return reader =>
+            {
+                if (!reader.CanGetColumnSchema())
+                {
+                    throw new ArgumentException($"Unable to get column schema from reader.");
+                }
+
+                var schema = reader.GetColumnSchema();
+                if (schema.Count != Members.Length)
+                {
+                    throw new ArgumentException(
+                        $"The number of attributes in the reader does not match the record type +" +
+                        $"'{typeof(T).FullName}'.",
+                        nameof(reader));
+                }
+
+                for (int i = 0; i < Members.Length; i++)
+                {
+                    var column = schema[i];
+                    var memberName = PascalCaseNamingConvention.Instance.Apply(column.ColumnName);
+                    if (memberName != Members[i].Name)
+                    {
+                        throw new ArgumentException(
+                            $"The column {memberName} does not match the corresponding attribute " +
+                            $"{Members[i].Name} in the record type '{typeof(T).FullName}'.",
+                            nameof(reader));
+                    }
+
+                    if (column.DataType != Members[i].PropertyType)
+                    {
+                        if (column.DataTypeName == "ENUM")
+                        {
+
+                        }
+                        else throw new ArgumentException(
+                            $"The type of the column {memberName} does not match the attribute " +
+                            $"{Members[i].PropertyType} {Members[i].Name} in the record type " +
+                            $"'{typeof(T).FullName}'.",
+                            nameof(reader));
+                    }
+                }
+            };
+        }
+
+        private static IEnumerable<Expression> CreateRecord(ParameterExpression reader, ParameterExpression record)
+        {
+            yield return Expression.Assign(record, Expression.New(typeof(T)));
+            for (int i = 0; i < Members.Length; i++)
+            {
+                Expression value;
+                var ordinal = Expression.Constant(i);
+                var member = Expression.PropertyOrField(record, Members[i].Name);
+                if (member.Type.IsEnum)
+                {
+                    var enumType = Expression.Constant(member.Type);
+                    var ignoreCase = Expression.Constant(true);
+                    value = Expression.Call(reader, nameof(MySqlDataReader.GetString), null, ordinal);
+                    value = Expression.Call(typeof(Enum), nameof(Enum.Parse), null, enumType, value, ignoreCase);
+                    yield return Expression.Assign(member, Expression.Convert(value, member.Type));
+                    continue;
+                }
+
+                var memberTypeCode = Type.GetTypeCode(member.Type);
+                switch (memberTypeCode)
+                {
+                    case TypeCode.Boolean:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetBooleanOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.Char:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetCharOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.SByte:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetSByteOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.Byte:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetByteOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.Int16:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetInt16OrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.UInt16:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetUInt16OrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.Int32:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetInt32OrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.UInt32:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetUInt32OrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.Int64:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetInt64OrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.UInt64:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetUInt64OrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.Single:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetFloatOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.Double:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetDoubleOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.Decimal:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetDecimalOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.DateTime:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetDateTimeOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    case TypeCode.String:
+                        value = Expression.Call(
+                            typeof(ObservableDatabase),
+                            nameof(ObservableDatabase.GetStringOrDefault),
+                            null, reader, ordinal, Expression.Default(member.Type));
+                        break;
+                    default:
+                        throw new NotSupportedException(
+                            "The specified primitive record type is not supported.");
+                }
+
+                yield return Expression.Assign(member, value);
+            }
+            yield return record;
+        }
+
+        private static Func<MySqlDataReader, T> CreateSelector()
+        {
+            ParameterExpression reader;
+            ParameterExpression record;
+            reader = Expression.Parameter(typeof(MySqlDataReader), nameof(reader));
+            record = Expression.Variable(typeof(T), nameof(record));
+
+            var body = Expression.Block(
+                typeof(T),
+                new[] { record },
+                CreateRecord(reader, record));
+            var lambda = Expression.Lambda<Func<MySqlDataReader, T>>(body, reader);
+            return lambda.Compile();
+        }
+    }
+}

--- a/src/Aeon.Database/RecordReader.cs
+++ b/src/Aeon.Database/RecordReader.cs
@@ -84,8 +84,7 @@ namespace Aeon.Database
                 {
                     var enumType = Expression.Constant(member.Type);
                     var ignoreCase = Expression.Constant(true);
-                    value = Expression.Call(reader, nameof(MySqlDataReader.GetString), null, ordinal);
-                    value = Expression.Call(typeof(Enum), nameof(Enum.Parse), null, enumType, value, ignoreCase);
+                    value = Expression.Call(reader, nameof(MySqlDataReader.GetChar), null, ordinal);
                     yield return Expression.Assign(member, Expression.Convert(value, member.Type));
                     continue;
                 }

--- a/src/Aeon.Database/RecordReader.cs
+++ b/src/Aeon.Database/RecordReader.cs
@@ -54,7 +54,9 @@ namespace Aeon.Database
                             nameof(reader));
                     }
 
-                    if (column.DataType != Members[i].PropertyType)
+                    var propertyType = Members[i].PropertyType;
+                    propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+                    if (column.DataType != propertyType)
                     {
                         if (column.DataTypeName == "ENUM")
                         {
@@ -88,98 +90,128 @@ namespace Aeon.Database
                     continue;
                 }
 
-                var memberTypeCode = Type.GetTypeCode(member.Type);
+                var nullableType = Nullable.GetUnderlyingType(member.Type);
+                var memberTypeCode = Type.GetTypeCode(nullableType ?? member.Type);
+                var isNullable = nullableType != null;
                 switch (memberTypeCode)
                 {
                     case TypeCode.Boolean:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetBooleanOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.BooleanField)
+                                : nameof(MySqlDataReader.GetBoolean),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.Char:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetCharOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.CharField)
+                                : nameof(MySqlDataReader.GetChar),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.SByte:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetSByteOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.SByteField)
+                                : nameof(MySqlDataReader.GetSByte),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.Byte:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetByteOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.ByteField)
+                                : nameof(MySqlDataReader.GetByte),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.Int16:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetInt16OrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.Int16Field)
+                                : nameof(MySqlDataReader.GetInt16),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.UInt16:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetUInt16OrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.UInt16Field)
+                                : nameof(MySqlDataReader.GetUInt16),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.Int32:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetInt32OrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.Int32Field)
+                                : nameof(MySqlDataReader.GetInt32),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.UInt32:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetUInt32OrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.UInt32Field)
+                                : nameof(MySqlDataReader.GetUInt32),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.Int64:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetInt64OrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.Int64Field)
+                                : nameof(MySqlDataReader.GetInt64),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.UInt64:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetUInt64OrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.UInt64Field)
+                                : nameof(MySqlDataReader.GetUInt64),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.Single:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetFloatOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.FloatField)
+                                : nameof(MySqlDataReader.GetFloat),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.Double:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetDoubleOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.DoubleField)
+                                : nameof(MySqlDataReader.GetDouble),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.Decimal:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetDecimalOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.DecimalField)
+                                : nameof(MySqlDataReader.GetDecimal),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.DateTime:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetDateTimeOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            isNullable
+                                ? nameof(ObservableDatabase.DateTimeField)
+                                : nameof(MySqlDataReader.GetDateTime),
+                            null, reader, ordinal);
                         break;
                     case TypeCode.String:
                         value = Expression.Call(
                             typeof(ObservableDatabase),
-                            nameof(ObservableDatabase.GetStringOrDefault),
-                            null, reader, ordinal, Expression.Default(member.Type));
+                            nameof(ObservableDatabase.StringField),
+                            null, reader, ordinal);
                         break;
                     default:
                         throw new NotSupportedException(

--- a/src/Aeon.sln
+++ b/src/Aeon.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		NuGet.config = NuGet.config
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aeon.Database", "Aeon.Database\Aeon.Database.csproj", "{D99F92A5-E825-4CDC-A7EB-849E860FB5B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{235C151D-1507-4EDA-8BE9-79FA24EE858E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{235C151D-1507-4EDA-8BE9-79FA24EE858E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{235C151D-1507-4EDA-8BE9-79FA24EE858E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D99F92A5-E825-4CDC-A7EB-849E860FB5B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D99F92A5-E825-4CDC-A7EB-849E860FB5B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D99F92A5-E825-4CDC-A7EB-849E860FB5B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D99F92A5-E825-4CDC-A7EB-849E860FB5B7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR introduces a new set of operators for interfacing with `aeondb`. The design is very minimalistic, requiring only a MySQL connection string and either free-form queries or domain-specific accessors. I will update the description of this issue with documentation and questions as the development is finalized.