### PR TITLE
Add support for sampling available system memory

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>build230921</VersionSuffix>
+    <VersionSuffix>build230922</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/AvailableMemory.cs
+++ b/src/Aeon.Acquisition/AvailableMemory.cs
@@ -1,0 +1,21 @@
+﻿using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace Aeon.Acquisition
+{
+    [Combinator]
+    [Description("Samples a performance counter reporting the available system memory, in megabytes.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class AvailableMemory
+    {
+        public IObservable<float> Process<TSource>(IObservable<TSource> source)
+        {
+            return Observable.Using(
+                () => new System.Diagnostics.PerformanceCounter("Memory", "Available MBytes"),
+                performance => source.Select(_ => performance.NextValue()));
+        }
+    }
+}


### PR DESCRIPTION
This PR moves the `AvailableMemory` operator into the core acquisition package to make it easier to develop online QC and system health monitors.