### PR TITLE
Add operator for timestamped replay of video data

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>build231005</VersionSuffix>
+    <VersionSuffix>build231007</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/LogPoseTracking.bonsai
+++ b/src/Aeon.Acquisition/LogPoseTracking.bonsai
@@ -28,6 +28,9 @@
         <MemberName>LogName</MemberName>
         <Value>PoseTrackingData</Value>
       </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" />
+      </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>PoseTrackingMetadata</Name>
       </Expression>
@@ -58,15 +61,16 @@
     <Edges>
       <Edge From="0" To="2" Label="Source1" />
       <Edge From="1" To="2" Label="Source2" />
-      <Edge From="2" To="10" Label="Source1" />
+      <Edge From="2" To="11" Label="Source1" />
       <Edge From="3" To="4" Label="Source1" />
-      <Edge From="4" To="6" Label="Source1" />
-      <Edge From="5" To="6" Label="Source2" />
-      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="4" To="7" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source2" />
       <Edge From="7" To="8" Label="Source1" />
       <Edge From="8" To="9" Label="Source1" />
-      <Edge From="9" To="10" Label="Source2" />
-      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source2" />
+      <Edge From="11" To="12" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/VideoFileCapture.cs
+++ b/src/Aeon.Acquisition/VideoFileCapture.cs
@@ -26,6 +26,7 @@ namespace Aeon.Acquisition
 
             return Observable.Defer(() =>
             {
+                var grayscale = new Grayscale();
                 var capture = new FileCapture { FileName = videoFileName };
                 var metadataFileName = System.IO.Path.ChangeExtension(videoFileName, ".csv");
                 var metadataContents = File.ReadAllLines(metadataFileName).Skip(1).Select(row =>
@@ -43,7 +44,7 @@ namespace Aeon.Acquisition
                     return (seconds, frameID, frameTimestamp);
                 }).ToArray();
 
-                return capture.Generate().Select((frame, index) =>
+                return grayscale.Process(capture.Generate()).Select((frame, index) =>
                 {
                     var (seconds, frameID, frameTimestamp) = metadataContents[index];
                     var dataFrame = new VideoDataFrame(frame, frameID, frameTimestamp);

--- a/src/Aeon.Acquisition/VideoFileCapture.cs
+++ b/src/Aeon.Acquisition/VideoFileCapture.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+using Bonsai.Harp;
+using Bonsai.Vision;
+
+namespace Aeon.Acquisition
+{
+    [Description("Configures and initializes a file capture for timestamped replay of video data.")]
+    public class VideoFileCapture : Source<Timestamped<VideoDataFrame>>
+    {
+        [Description("The path to the file used to source the video frames.")]
+        public string Path { get; set; }
+
+        public override IObservable<Timestamped<VideoDataFrame>> Generate()
+        {
+            var videoFileName = Path;
+            if (string.IsNullOrEmpty(videoFileName))
+            {
+                throw new InvalidOperationException("A valid file name must be specified");
+            }
+
+            return Observable.Defer(() =>
+            {
+                var capture = new FileCapture { FileName = videoFileName };
+                var metadataFileName = System.IO.Path.ChangeExtension(videoFileName, ".csv");
+                var metadataContents = File.ReadAllLines(metadataFileName).Skip(1).Select(row =>
+                {
+                    var values = row.Split(',');
+                    if (values.Length != 3 ||
+                        !double.TryParse(values[0], out double seconds) ||
+                        !long.TryParse(values[1], out long frameID) ||
+                        !long.TryParse(values[2], out long frameTimestamp))
+                    {
+                        throw new InvalidOperationException(
+                            "Frame metadata file should be in 3-column comma-separated text format.");
+                    }
+
+                    return (seconds, frameID, frameTimestamp);
+                }).ToArray();
+
+                return capture.Generate().Select((frame, index) =>
+                {
+                    var (seconds, frameID, frameTimestamp) = metadataContents[index];
+                    var dataFrame = new VideoDataFrame(frame, frameID, frameTimestamp);
+                    return Timestamped.Create(dataFrame, seconds);
+                });
+            });
+        }
+    }
+}

--- a/src/Aeon.Acquisition/VideoFileCapture.cs
+++ b/src/Aeon.Acquisition/VideoFileCapture.cs
@@ -13,6 +13,7 @@ namespace Aeon.Acquisition
     public class VideoFileCapture : Source<Timestamped<VideoDataFrame>>
     {
         [Description("The path to the file used to source the video frames.")]
+        [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
         public string Path { get; set; }
 
         public override IObservable<Timestamped<VideoDataFrame>> Generate()


### PR DESCRIPTION
This PR adds a new video capture operator for timestamped replay of video data acquired by the Aeon system. It assumes frame metadata is provided next to the video file and by default performs automatic grayscale conversion so that the output format is identical to the video streams coming in from cameras during live acquisition workflows (this conversion is exposed as an optional parameter for future color camera or alternative color format support).

The aim is to provide support for testing video processing workflows and also enabling offline post-hoc conversion of derived video datasets.