### PR TITLE
Ensure unit tests check for indirect references

### DIFF
--- a/src/Aeon.Foraging/Aeon.Foraging.csproj
+++ b/src/Aeon.Foraging/Aeon.Foraging.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Foraging</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build230921</VersionSuffix>
+    <VersionSuffix>build231007</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Foraging/LinearDepletion.bonsai
+++ b/src/Aeon.Foraging/LinearDepletion.bonsai
@@ -67,7 +67,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:PrependOnce" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:DistanceTravelled.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:DistanceTravelled.bonsai">
         <Gain>1</Gain>
       </Expression>
       <Expression xsi:type="MulticastSubject">

--- a/src/Aeon.Foraging/RandomDepletion.bonsai
+++ b/src/Aeon.Foraging/RandomDepletion.bonsai
@@ -68,7 +68,7 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:PrependOnce" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:DistanceTravelled.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:DistanceTravelled.bonsai">
         <Gain>1</Gain>
       </Expression>
       <Expression xsi:type="MulticastSubject">

--- a/src/Aeon.Foraging/TimeSpentOnWheel.bonsai
+++ b/src/Aeon.Foraging/TimeSpentOnWheel.bonsai
@@ -40,7 +40,7 @@
         <Property Name="Threshold" />
         <Property Name="LowPass" />
       </Expression>
-      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:WheelMovement.bonsai">
+      <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:WheelMoving.bonsai">
         <LowPass>5</LowPass>
         <Threshold>0.0005</Threshold>
       </Expression>

--- a/src/Aeon.Tests/AssertWorkflow.cs
+++ b/src/Aeon.Tests/AssertWorkflow.cs
@@ -27,6 +27,16 @@ namespace Aeon.Tests
                     workflowBuilder.Workflow.Convert(builder =>
                     {
                         var workflowElement = ExpressionBuilder.GetWorkflowElement(builder);
+                        if (workflowElement is IncludeWorkflowBuilder includeWorkflow)
+                        {
+                            var pathComponents = includeWorkflow.Path.Split(':');
+                            var assembly = Assembly.Load(pathComponents[0]);
+                            var resourceName = string.Join(ExpressionHelper.MemberSeparator, pathComponents);
+                            Assert.IsNotNull(
+                                assembly.GetManifestResourceStream(resourceName),
+                                $"Embedded workflow: {name}. Missing resource name: {resourceName}");
+                        }
+
                         if (workflowElement.GetType().Name != nameof(SpinnakerCapture) &&
                             workflowElement.GetType().Name != nameof(PylonCapture) &&
 #pragma warning disable CS0612 // Type or member is obsolete


### PR DESCRIPTION
This PR improves the automated testing infrastructure to check for missing indirect references to embedded workflows. It assumes that all `IncludeWorkflow` references must be assembly-qualified since file extensions should be disallowed anyway for embedded workflows.

Fixes #153 