### PR TITLE
Include resource name in unit test serialization errors

### DIFF
--- a/src/Aeon.Foraging/Aeon.Foraging.csproj
+++ b/src/Aeon.Foraging/Aeon.Foraging.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Foraging</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231007</VersionSuffix>
+    <VersionSuffix>build231008</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Foraging/LinearDepletion.bonsai
+++ b/src/Aeon.Foraging/LinearDepletion.bonsai
@@ -2,6 +2,7 @@
 <WorkflowBuilder Version="2.7.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
+                 xmlns:aeon-env="clr-namespace:Aeon.Environment;assembly=Aeon.Environment"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -31,7 +32,7 @@
               <Selector>Value.Type</Selector>
             </Expression>
             <Expression xsi:type="Equal">
-              <Operand xsi:type="WorkflowProperty" TypeArguments="aeon:EnvironmentStateType">
+              <Operand xsi:type="WorkflowProperty" TypeArguments="aeon-env:EnvironmentStateType">
                 <Value>Experiment</Value>
               </Operand>
             </Expression>
@@ -92,7 +93,7 @@
                     <Selector>Value.Type</Selector>
                   </Expression>
                   <Expression xsi:type="Equal">
-                    <Operand xsi:type="WorkflowProperty" TypeArguments="aeon:EnvironmentSubjectChangeType">
+                    <Operand xsi:type="WorkflowProperty" TypeArguments="aeon-env:EnvironmentSubjectChangeType">
                       <Value>Enter</Value>
                     </Operand>
                   </Expression>

--- a/src/Aeon.Foraging/RandomDepletion.bonsai
+++ b/src/Aeon.Foraging/RandomDepletion.bonsai
@@ -2,6 +2,7 @@
 <WorkflowBuilder Version="2.7.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
+                 xmlns:aeon-env="clr-namespace:Aeon.Environment;assembly=Aeon.Environment"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
@@ -32,7 +33,7 @@
               <Selector>Value.Type</Selector>
             </Expression>
             <Expression xsi:type="Equal">
-              <Operand xsi:type="WorkflowProperty" TypeArguments="aeon:EnvironmentStateType">
+              <Operand xsi:type="WorkflowProperty" TypeArguments="aeon-env:EnvironmentStateType">
                 <Value>Experiment</Value>
               </Operand>
             </Expression>
@@ -93,7 +94,7 @@
                     <Selector>Value.Type</Selector>
                   </Expression>
                   <Expression xsi:type="Equal">
-                    <Operand xsi:type="WorkflowProperty" TypeArguments="aeon:EnvironmentSubjectChangeType">
+                    <Operand xsi:type="WorkflowProperty" TypeArguments="aeon-env:EnvironmentSubjectChangeType">
                       <Value>Enter</Value>
                     </Operand>
                   </Expression>

--- a/src/Aeon.Tests/Aeon.Tests.csproj
+++ b/src/Aeon.Tests/Aeon.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <TargetFramework>net472</TargetFramework>
-    <Version>0.3.0</Version>
+    <Version>0.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aeon.Tests/AssertWorkflow.cs
+++ b/src/Aeon.Tests/AssertWorkflow.cs
@@ -36,6 +36,15 @@ namespace Aeon.Tests
                                 assembly.GetManifestResourceStream(resourceName),
                                 $"Embedded workflow: {name}. Missing resource name: {resourceName}");
                         }
+                        else if (workflowElement is BinaryOperatorBuilder binaryOperator &&
+                                 binaryOperator.Operand is WorkflowProperty operand &&
+                                 operand.GetType().IsGenericType)
+                        {
+                            var valueType = operand.GetType().GetGenericArguments()[0];
+                            Assert.IsFalse(
+                                typeof(UnknownTypeBuilder).IsAssignableFrom(valueType),
+                                $"Binary operator operand is unknown: {valueType}. Embedded workflow: {name}.");
+                        }
 
                         if (workflowElement.GetType().Name != nameof(SpinnakerCapture) &&
                             workflowElement.GetType().Name != nameof(PylonCapture) &&

--- a/src/Aeon.Tests/AssertWorkflow.cs
+++ b/src/Aeon.Tests/AssertWorkflow.cs
@@ -5,6 +5,7 @@ using System.IO;
 using Bonsai.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Aeon.Acquisition;
+using System;
 
 namespace Aeon.Tests
 {
@@ -23,7 +24,17 @@ namespace Aeon.Tests
                 using (var reader = XmlReader.Create(workflowStream))
                 {
                     reader.MoveToContent();
-                    var workflowBuilder = (WorkflowBuilder)WorkflowBuilder.Serializer.Deserialize(reader);
+                    WorkflowBuilder workflowBuilder;
+                    try { workflowBuilder = (WorkflowBuilder)WorkflowBuilder.Serializer.Deserialize(reader); }
+                    catch (Exception ex)
+                    {
+                        var message = ex.ToString().Split(
+                            new[] { System.Environment.NewLine },
+                            StringSplitOptions.None)[0];
+                        Assert.Fail($"Embedded workflow {name} threw exception:\n{message}");
+                        break;
+                    }
+
                     workflowBuilder.Workflow.Convert(builder =>
                     {
                         var workflowElement = ExpressionBuilder.GetWorkflowElement(builder);


### PR DESCRIPTION
This PR ensures that any unexpected serialization exceptions raised during embedded workflow unit tests are marked with the resource name of the affected workflow, to make it easier to trace the source of the problem.

Binary operators are also now checked for unknown types as they were found to be silently impacted by type refactoring.

Fixes #156 