### PR TITLE
Update annotation control to save layout space

### DIFF
--- a/src/Aeon.Environment/Aeon.Environment.csproj
+++ b/src/Aeon.Environment/Aeon.Environment.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Environment</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231007</VersionSuffix>
+    <VersionSuffix>build231008</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Environment/AnnotationControl.Designer.cs
+++ b/src/Aeon.Environment/AnnotationControl.Designer.cs
@@ -29,17 +29,15 @@
         private void InitializeComponent()
         {
             this.annotationsPanel = new System.Windows.Forms.Panel();
-            this.annotationsGroupBox = new System.Windows.Forms.GroupBox();
             this.annotationsTextBox = new System.Windows.Forms.TextBox();
             this.alertButton = new System.Windows.Forms.Button();
             this.annotationButton = new System.Windows.Forms.Button();
             this.annotationsPanel.SuspendLayout();
-            this.annotationsGroupBox.SuspendLayout();
             this.SuspendLayout();
             // 
             // annotationsPanel
             // 
-            this.annotationsPanel.Controls.Add(this.annotationsGroupBox);
+            this.annotationsPanel.Controls.Add(this.annotationsTextBox);
             this.annotationsPanel.Controls.Add(this.alertButton);
             this.annotationsPanel.Controls.Add(this.annotationButton);
             this.annotationsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
@@ -49,36 +47,23 @@
             this.annotationsPanel.Size = new System.Drawing.Size(400, 374);
             this.annotationsPanel.TabIndex = 10;
             // 
-            // annotationsGroupBox
-            // 
-            this.annotationsGroupBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.annotationsGroupBox.Controls.Add(this.annotationsTextBox);
-            this.annotationsGroupBox.Location = new System.Drawing.Point(12, 12);
-            this.annotationsGroupBox.Margin = new System.Windows.Forms.Padding(12);
-            this.annotationsGroupBox.Name = "annotationsGroupBox";
-            this.annotationsGroupBox.Padding = new System.Windows.Forms.Padding(12);
-            this.annotationsGroupBox.Size = new System.Drawing.Size(375, 279);
-            this.annotationsGroupBox.TabIndex = 4;
-            this.annotationsGroupBox.TabStop = false;
-            this.annotationsGroupBox.Text = "Annotations";
-            // 
             // annotationsTextBox
             // 
-            this.annotationsTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.annotationsTextBox.Location = new System.Drawing.Point(12, 43);
+            this.annotationsTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.annotationsTextBox.Location = new System.Drawing.Point(14, 12);
             this.annotationsTextBox.Margin = new System.Windows.Forms.Padding(12);
             this.annotationsTextBox.Multiline = true;
             this.annotationsTextBox.Name = "annotationsTextBox";
-            this.annotationsTextBox.Size = new System.Drawing.Size(351, 224);
+            this.annotationsTextBox.Size = new System.Drawing.Size(374, 296);
             this.annotationsTextBox.TabIndex = 0;
             this.annotationsTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.annotationBox_KeyDown);
             // 
             // alertButton
             // 
             this.alertButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.alertButton.Location = new System.Drawing.Point(227, 303);
+            this.alertButton.Location = new System.Drawing.Point(227, 313);
             this.alertButton.Margin = new System.Windows.Forms.Padding(12);
             this.alertButton.Name = "alertButton";
             this.alertButton.Size = new System.Drawing.Size(160, 52);
@@ -91,7 +76,7 @@
             // 
             this.annotationButton.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.annotationButton.Location = new System.Drawing.Point(24, 303);
+            this.annotationButton.Location = new System.Drawing.Point(13, 313);
             this.annotationButton.Margin = new System.Windows.Forms.Padding(12);
             this.annotationButton.Name = "annotationButton";
             this.annotationButton.Size = new System.Drawing.Size(190, 52);
@@ -102,7 +87,7 @@
             // 
             // AnnotationControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(16F, 31F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(13F, 26F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.annotationsPanel);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 16.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -110,8 +95,7 @@
             this.Name = "AnnotationControl";
             this.Size = new System.Drawing.Size(400, 374);
             this.annotationsPanel.ResumeLayout(false);
-            this.annotationsGroupBox.ResumeLayout(false);
-            this.annotationsGroupBox.PerformLayout();
+            this.annotationsPanel.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -119,7 +103,6 @@
         #endregion
 
         private System.Windows.Forms.Panel annotationsPanel;
-        private System.Windows.Forms.GroupBox annotationsGroupBox;
         private System.Windows.Forms.TextBox annotationsTextBox;
         private System.Windows.Forms.Button alertButton;
         private System.Windows.Forms.Button annotationButton;


### PR DESCRIPTION
When laying out compositions in table layout panel, several controls would benefit from packing their margins and save as much space in the layout as possible. This really makes a difference in screens with limited space.