### PR TITLE
Add processed weight streams to scale output

### DIFF
--- a/src/Aeon.Environment/Aeon.Environment.csproj
+++ b/src/Aeon.Environment/Aeon.Environment.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Environment</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231008</VersionSuffix>
+    <VersionSuffix>build231009</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Environment/WeightBaseline.cs
+++ b/src/Aeon.Environment/WeightBaseline.cs
@@ -14,7 +14,7 @@ namespace Aeon.Environment
         public IObservable<WeightMeasurement> Process<TOther>(IObservable<WeightMeasurement> source, IObservable<TOther> trigger)
         {
             return source
-                .Window(trigger).Skip(1)
+                .Window(trigger)
                 .SelectMany(window =>
                     window.Publish(pwindow =>
                         pwindow.Take(1).CombineLatest(pwindow, (reference, measurement) =>

--- a/src/Aeon.Environment/WeightMeasurement.cs
+++ b/src/Aeon.Environment/WeightMeasurement.cs
@@ -12,5 +12,10 @@
             Value = value;
             Confidence = confidence;
         }
+
+        public override string ToString()
+        {
+            return $"{nameof(WeightMeasurement)}(Seconds: {Timestamp}, Value: {Value}, Confidence: {Confidence})";
+        }
     }
 }

--- a/src/Aeon.Environment/WeightRaw.cs
+++ b/src/Aeon.Environment/WeightRaw.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.ComponentModel;
+using Bonsai;
+
+namespace Aeon.Environment
+{
+    [Description("Provides a type signature for converting values into weight measurements.")]
+    public class WeightRaw : Transform<WeightMeasurement, WeightMeasurement>
+    {
+        public override IObservable<WeightMeasurement> Process(IObservable<WeightMeasurement> source)
+        {
+            return source;
+        }
+    }
+}

--- a/src/Aeon.Environment/WeightScale.bonsai
+++ b/src/Aeon.Environment/WeightScale.bonsai
@@ -4,8 +4,9 @@
                  xmlns:port="clr-namespace:Bonsai.IO.Ports;assembly=Bonsai.System"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
-                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
+                 xmlns:aeon-env="clr-namespace:Aeon.Environment;assembly=Aeon.Environment"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>Contains acquisition functionality for automated arena weighing scales.</Description>
   <Workflow>
@@ -61,21 +62,141 @@ Item2.Contains("?") ? 0.0 : 1.0 as Confidence)</scr:Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:WithLatestFrom" />
       </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="harp:CreateTimestamped" />
+      <Expression xsi:type="InputMapping">
+        <PropertyMappings />
+        <Selector>Item2,Item1.Weight,Item1.Confidence</Selector>
+        <TypeMapping xsi:type="TypeMapping" TypeArguments="aeon-env:WeightMeasurement" />
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Name" DisplayName="WeightEvents" Description="The name of the output sequence containing all weight events." />
+        <Property Name="Name" DisplayName="BaselineWeightTrigger" Description="The name of the notification sequence used to reset the baseline for weight measurements." />
+      </Expression>
+      <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Object">
+        <rx:Name>BaselineWeightTrigger</rx:Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="FilterWindow" />
+      </Expression>
+      <Expression xsi:type="rx:Defer">
+        <Name>ProcessWeight</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source1</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="aeon-env:WeightRaw" />
+            </Expression>
+            <Expression xsi:type="rx:PublishSubject">
+              <Name>RawWeight</Name>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Count" DisplayName="FilterWindow" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="aeon-env:WeightFilter">
+                <aeon-env:Count>40</aeon-env:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:PublishSubject">
+              <Name>FilteredWeight</Name>
+            </Expression>
+            <Expression xsi:type="WorkflowInput">
+              <Name>Source2</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="aeon-env:WeightBaseline" />
+            </Expression>
+            <Expression xsi:type="rx:PublishSubject">
+              <Name>BaselinedWeight</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>RawWeight</Name>
+            </Expression>
+            <Expression xsi:type="GroupWorkflow">
+              <Name>SampleOffset</Name>
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="ExternalizedMapping">
+                    <Property Name="Value" DisplayName="Count" />
+                  </Expression>
+                  <Expression xsi:type="PropertySource" TypeArguments="rx:Skip,sys:Int32">
+                    <MemberName>Count</MemberName>
+                    <Value>40</Value>
+                  </Expression>
+                  <Expression xsi:type="Subtract">
+                    <Operand xsi:type="IntProperty">
+                      <Value>1</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="Count" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Skip">
+                <rx:Count>39</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>FilteredWeight</Name>
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>BaselinedWeight</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Zip" />
+            </Expression>
+            <Expression xsi:type="scr:ExpressionTransform">
+              <scr:Expression>new(
+Item1 as RawWeight,
+Item2 as FilteredWeight,
+Item3 as BaselinedWeight)</scr:Expression>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+            <Edge From="2" To="4" Label="Source1" />
+            <Edge From="3" To="4" Label="Source2" />
+            <Edge From="3" To="10" Label="Source1" />
+            <Edge From="4" To="5" Label="Source1" />
+            <Edge From="5" To="7" Label="Source1" />
+            <Edge From="6" To="7" Label="Source2" />
+            <Edge From="7" To="8" Label="Source1" />
+            <Edge From="9" To="12" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="12" Label="Source2" />
+            <Edge From="12" To="15" Label="Source1" />
+            <Edge From="13" To="15" Label="Source2" />
+            <Edge From="14" To="15" Label="Source3" />
+            <Edge From="15" To="16" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+          </Edges>
+        </Workflow>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="WeightData" Description="The name of the output sequence containing all weight measurements." />
       </Expression>
       <Expression xsi:type="rx:PublishSubject">
-        <Name>WeightEvents</Name>
+        <Name>WeightData</Name>
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
       <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Name" DisplayName="TareWeight" Description="The name of the input sequence with tare commands to be sent to the weight scale." />
+        <Property Name="Name" DisplayName="TareCommands" Description="The name of the input sequence with tare commands to be sent to the weight scale." />
       </Expression>
       <Expression xsi:type="rx:BehaviorSubject" TypeArguments="sys:Object">
-        <rx:Name>TareWeight</rx:Name>
+        <rx:Name>TareCommands</rx:Name>
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="StringProperty">
@@ -112,7 +233,7 @@ Item2.Contains("?") ? 0.0 : 1.0 as Confidence)</scr:Expression>
     <Edges>
       <Edge From="0" To="1" Label="Source1" />
       <Edge From="0" To="2" Label="Source1" />
-      <Edge From="0" To="18" Label="Source2" />
+      <Edge From="0" To="22" Label="Source2" />
       <Edge From="2" To="3" Label="Source1" />
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="5" Label="Source1" />
@@ -123,19 +244,23 @@ Item2.Contains("?") ? 0.0 : 1.0 as Confidence)</scr:Expression>
       <Edge From="8" To="10" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
       <Edge From="10" To="11" Label="Source1" />
-      <Edge From="11" To="13" Label="Source1" />
-      <Edge From="12" To="13" Label="Source2" />
-      <Edge From="13" To="14" Label="Source1" />
-      <Edge From="15" To="16" Label="Source1" />
-      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="11" To="15" Label="Source1" />
+      <Edge From="12" To="13" Label="Source1" />
+      <Edge From="13" To="15" Label="Source2" />
+      <Edge From="14" To="15" Label="Source3" />
+      <Edge From="15" To="17" Label="Source1" />
+      <Edge From="16" To="17" Label="Source2" />
       <Edge From="17" To="18" Label="Source1" />
-      <Edge From="18" To="19" Label="Source1" />
-      <Edge From="19" To="22" Label="Source1" />
+      <Edge From="19" To="20" Label="Source1" />
       <Edge From="20" To="21" Label="Source1" />
-      <Edge From="21" To="22" Label="Source2" />
+      <Edge From="21" To="22" Label="Source1" />
       <Edge From="22" To="23" Label="Source1" />
-      <Edge From="23" To="25" Label="Source1" />
-      <Edge From="24" To="25" Label="Source2" />
+      <Edge From="23" To="26" Label="Source1" />
+      <Edge From="24" To="25" Label="Source1" />
+      <Edge From="25" To="26" Label="Source2" />
+      <Edge From="26" To="27" Label="Source1" />
+      <Edge From="27" To="29" Label="Source1" />
+      <Edge From="28" To="29" Label="Source2" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
This PR aligns the raw weight stream with the filtered and baselined weight streams, both for ease of monitoring and later post-hoc analysis. It also avoids inconsistencies which were creeping up, where the size of the filter window was changed without simultaneously adjusting the number of samples to skip for monitoring.

By combining these other streams, the data is guaranteed to be consistent.