### PR TITLE
Ensure all tracking operators use timestamped values

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>build231008</VersionSuffix>
+    <VersionSuffix>build231009</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/DistanceFromPoint.cs
+++ b/src/Aeon.Acquisition/DistanceFromPoint.cs
@@ -23,22 +23,31 @@ namespace Aeon.Acquisition
             return Math.Sqrt(delta.X * delta.X + delta.Y * delta.Y);
         }
 
-        public IObservable<Timestamped<double>> Process(IObservable<Tuple<ConnectedComponent, double>> source)
+        public IObservable<Timestamped<double>> Process(IObservable<Timestamped<Point2f>> source)
         {
             return source.Select(x =>
             {
-                var distance = Distance(x.Item1.Centroid, new Point2f(Value));
-                return Timestamped.Create(distance, x.Item2);
+                var distance = Distance(x.Value, new Point2f(Value));
+                return Timestamped.Create(distance, x.Seconds);
             });
         }
 
-        public IObservable<Timestamped<double>> Process(IObservable<Tuple<ConnectedComponentCollection, double>> source)
+        public IObservable<Timestamped<double>> Process(IObservable<Timestamped<ConnectedComponent>> source)
+        {
+            return source.Select(x =>
+            {
+                var distance = Distance(x.Value.Centroid, new Point2f(Value));
+                return Timestamped.Create(distance, x.Seconds);
+            });
+        }
+
+        public IObservable<Timestamped<double>> Process(IObservable<Timestamped<ConnectedComponentCollection>> source)
         {
             return source.Select(x =>
             {
                 var point = new Point2f(Value);
-                var distance = x.Item1.Min(component => Distance(point, component.Centroid));
-                return Timestamped.Create(distance, x.Item2);
+                var distance = x.Value.Min(component => Distance(point, component.Centroid));
+                return Timestamped.Create(distance, x.Seconds);
             });
         }
     }

--- a/src/Aeon.Acquisition/FormatBinaryRegions.cs
+++ b/src/Aeon.Acquisition/FormatBinaryRegions.cs
@@ -1,4 +1,4 @@
-using Bonsai;
+﻿using Bonsai;
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -15,12 +15,12 @@ namespace Aeon.Acquisition
     {
         const int Address = 200;
 
-        public IObservable<HarpMessage> Process(IObservable<Tuple<ConnectedComponent, double>> source)
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ConnectedComponent>> source)
         {
-            return source.Select(value =>
+            return source.Select(x =>
             {
-                var region = value.Item1;
-                var timestamp = value.Item2;
+                var region = x.Value;
+                var timestamp = x.Seconds;
                 return HarpMessage.FromSingle(
                     Address,
                     timestamp,
@@ -34,12 +34,12 @@ namespace Aeon.Acquisition
             });
         }
 
-        public IObservable<HarpMessage> Process(IObservable<Tuple<ConnectedComponentCollection, double>> source)
+        public IObservable<HarpMessage> Process(IObservable<Timestamped<ConnectedComponentCollection>> source)
         {
-            return source.SelectMany(value =>
+            return source.SelectMany(x =>
             {
-                var regions = value.Item1;
-                var timestamp = value.Item2;
+                var regions = x.Value;
+                var timestamp = x.Seconds;
                 return regions.Select((region, index) => HarpMessage.FromSingle(
                     Address,
                     timestamp,

--- a/src/Aeon.Acquisition/PositionTracking.bonsai
+++ b/src/Aeon.Acquisition/PositionTracking.bonsai
@@ -4,6 +4,7 @@
                  xmlns:cv="clr-namespace:Bonsai.Vision;assembly=Bonsai.Vision"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
+                 xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>Extracts information on the largest binary blob in the input image.</Description>
   <Workflow>
@@ -76,6 +77,9 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Zip" />
       </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="harp:CreateTimestamped" />
+      </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="TrackingEvents" />
       </Expression>
@@ -100,9 +104,10 @@
       <Edge From="11" To="12" Label="Source2" />
       <Edge From="12" To="14" Label="Source1" />
       <Edge From="13" To="14" Label="Source2" />
-      <Edge From="14" To="16" Label="Source1" />
-      <Edge From="15" To="16" Label="Source2" />
-      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="17" Label="Source1" />
+      <Edge From="16" To="17" Label="Source2" />
+      <Edge From="17" To="18" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/RegionContainsPoint.cs
+++ b/src/Aeon.Acquisition/RegionContainsPoint.cs
@@ -34,22 +34,31 @@ namespace Aeon.Acquisition
             return false;
         }
 
-        public IObservable<Timestamped<bool>> Process(IObservable<Tuple<ConnectedComponent, double>> source)
+        public IObservable<Timestamped<bool>> Process(IObservable<Timestamped<Point2f>> source)
         {
             return source.Select(x =>
             {
-                var containsPoint = Contains(Regions, x.Item1.Centroid);
-                return Timestamped.Create(containsPoint, x.Item2);
+                var containsPoint = Contains(Regions, x.Value);
+                return Timestamped.Create(containsPoint, x.Seconds);
             });
         }
 
-        public IObservable<Timestamped<bool>> Process(IObservable<Tuple<ConnectedComponentCollection, double>> source)
+        public IObservable<Timestamped<bool>> Process(IObservable<Timestamped<ConnectedComponent>> source)
+        {
+            return source.Select(x =>
+            {
+                var containsPoint = Contains(Regions, x.Value.Centroid);
+                return Timestamped.Create(containsPoint, x.Seconds);
+            });
+        }
+
+        public IObservable<Timestamped<bool>> Process(IObservable<Timestamped<ConnectedComponentCollection>> source)
         {
             return source.Select(x =>
             {
                 var regions = Regions;
-                var containsPoint = x.Item1.Any(component => Contains(regions, component.Centroid));
-                return Timestamped.Create(containsPoint, x.Item2);
+                var containsPoint = x.Value.Any(component => Contains(regions, component.Centroid));
+                return Timestamped.Create(containsPoint, x.Seconds);
             });
         }
     }


### PR DESCRIPTION
This PR refactors and aligns the few missing operators which were still using unnamed tuples of value / timestamp to emit and manipulate only `Timestamped<T>` sequences of values.

Every other present and future tracking operator will be defined in terms of this generic type. While it is a breaking change, in practice if all operators are updated synchronously the impact of changes to existing workflows is small, and I believe are very much outweighed by the potential gains of performing this refactoring now.