### PR TITLE
Add support for spatial parsing of RFID events

### DIFF
--- a/src/Aeon.Environment/Aeon.Environment.csproj
+++ b/src/Aeon.Environment/Aeon.Environment.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Environment</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231010</VersionSuffix>
+    <VersionSuffix>build231011</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Environment/ParseRfidMeasurement.cs
+++ b/src/Aeon.Environment/ParseRfidMeasurement.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+using Bonsai.Harp;
+using Harp.RfidReader;
+using OpenCV.Net;
+
+namespace Aeon.Environment
+{
+    [Description("Generates a sequence of spatialized detection events when a tag enters the area of the reader.")]
+    public class ParseRfidMeasurement : Transform<HarpMessage, Timestamped<RfidMeasurement>>
+    {
+        [Description("The location to associate with each detection event.")]
+        public Point2f Location { get; set; }
+
+        public override IObservable<Timestamped<RfidMeasurement>> Process(IObservable<HarpMessage> source)
+        {
+            return source.Select(message =>
+            {
+                var (tagId, timestamp) = InboundDetectionId.GetTimestampedPayload(message);
+                return Timestamped.Create(new RfidMeasurement(Location, tagId), timestamp);
+            });
+        }
+    }
+}

--- a/src/Aeon.Environment/RfidMeasurement.cs
+++ b/src/Aeon.Environment/RfidMeasurement.cs
@@ -1,0 +1,21 @@
+﻿using OpenCV.Net;
+
+namespace Aeon.Environment
+{
+    public struct RfidMeasurement
+    {
+        public Point2f Location;
+        public ulong TagId;
+
+        public RfidMeasurement(Point2f location, ulong tagId)
+        {
+            Location = location;
+            TagId = tagId;
+        }
+
+        public override readonly string ToString()
+        {
+            return $"{nameof(RfidMeasurement)}(Location: {Location}, TagId: {TagId})";
+        }
+    }
+}

--- a/src/Aeon.Environment/RfidReader.bonsai
+++ b/src/Aeon.Environment/RfidReader.bonsai
@@ -4,6 +4,7 @@
                  xmlns:p1="clr-namespace:Harp.RfidReader;assembly=Harp.RfidReader"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:aeon-env="clr-namespace:Aeon.Environment;assembly=Aeon.Environment"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>Provides functionality for synchronizing and detecting inbound tags from an RFID reader module.</Description>
   <Workflow>
@@ -51,8 +52,16 @@
         <Name>RfidEvents</Name>
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
-      <Expression xsi:type="p1:Parse">
-        <harp:Register xsi:type="p1:TimestampedInboundDetectionId" />
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Location" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon-env:ParseRfidMeasurement">
+          <aeon-env:Location>
+            <aeon-env:X>0</aeon-env:X>
+            <aeon-env:Y>0</aeon-env:Y>
+          </aeon-env:Location>
+        </Combinator>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="InboundRfidDetected" Description="The name of the output sequence carrying detected inbound RFID notifications." />
@@ -72,9 +81,10 @@
       <Edge From="7" To="9" Label="Source1" />
       <Edge From="8" To="9" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
-      <Edge From="9" To="11" Label="Source1" />
-      <Edge From="11" To="13" Label="Source1" />
-      <Edge From="12" To="13" Label="Source2" />
+      <Edge From="9" To="12" Label="Source1" />
+      <Edge From="11" To="12" Label="Source2" />
+      <Edge From="12" To="14" Label="Source1" />
+      <Edge From="13" To="14" Label="Source2" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
RFID readers are in general associated with a spatial location to be interpretable. This PR exposes a new `Location` property for `RfidReader` that associates a specified 2D point with each antenna. This location can be in image-space or other coordinate reference systems such as SI units.

The goal is to make it easier to provide spatialized elements of the location of each subject without having to resolve names into locations (i.e. the association between the detection and a location is provided at the source).