### PR TITLE
Ensure timestamp is ready on source subscription

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>build231009</VersionSuffix>
+    <VersionSuffix>build231010</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/MetadataSource.cs
+++ b/src/Aeon.Acquisition/MetadataSource.cs
@@ -25,15 +25,7 @@ namespace Aeon.Acquisition
 
         public virtual IObservable<Timestamped<TMetadata>> Process(IObservable<HarpMessage> source)
         {
-            return source.Publish(
-                ps => Process().Publish(
-                    xs => xs.CombineLatest(ps, (data, message) => (data, message))
-                            .Sample(xs.MergeUnit(ps.Take(1)))
-                            .Select(x =>
-                            {
-                                var timestamp = x.message.GetTimestamp();
-                                return Timestamped.Create(x.data, timestamp);
-                            })));
+            return Process().Timestamp(source);
         }
     }
 }

--- a/src/Aeon.Acquisition/ObservableExtensions.cs
+++ b/src/Aeon.Acquisition/ObservableExtensions.cs
@@ -60,8 +60,9 @@ namespace Aeon.Acquisition
             {
                 var pc = clock.Publish();
                 var ps = source.Publish();
+                var sourceSubscription = new SingleAssignmentDisposable();
                 var trigger = Observer.Create<HarpMessage>(
-                    _ => ps.Connect(),
+                    _ => sourceSubscription.Disposable = ps.Connect(),
                     observer.OnError);
                 var result = ps.CombineLatest(pc, (data, message) => (data, message))
                                .Sample(ps.MergeUnit(pc.Take(1)))
@@ -73,6 +74,7 @@ namespace Aeon.Acquisition
                 return new CompositeDisposable(
                     result.SubscribeSafe(observer),
                     pc.Take(1).SubscribeSafe(trigger),
+                    sourceSubscription,
                     pc.Connect());
             });
         }


### PR DESCRIPTION
This PR fixes a subtle issue with timestamped metadata sources where values would be silently dropped if no timestamps were available at subscription time. The resolution is to ensure that at least one timestamp must be available before subscription to the source is attempted, to ensure that timestamp pairings are always available, even if the source produces notification values immediately on subscription.

Specifically, this fixes the issue where state recovery subjects would silently drop the initial values when storing multi-value collections.

Fixes #168 