### PR TITLE
Ensure parse is applied on the right register

### DIFF
--- a/src/Aeon.Environment/Aeon.Environment.csproj
+++ b/src/Aeon.Environment/Aeon.Environment.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Environment</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231011</VersionSuffix>
+    <VersionSuffix>build231012</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Environment/ParseRfidMeasurement.cs
+++ b/src/Aeon.Environment/ParseRfidMeasurement.cs
@@ -10,14 +10,14 @@ using OpenCV.Net;
 namespace Aeon.Environment
 {
     [Description("Generates a sequence of spatialized detection events when a tag enters the area of the reader.")]
-    public class ParseRfidMeasurement : Transform<HarpMessage, Timestamped<RfidMeasurement>>
+    public class ParseRfidMeasurement : Combinator<HarpMessage, Timestamped<RfidMeasurement>>
     {
         [Description("The location to associate with each detection event.")]
         public Point2f Location { get; set; }
 
         public override IObservable<Timestamped<RfidMeasurement>> Process(IObservable<HarpMessage> source)
         {
-            return source.Select(message =>
+            return source.Where(InboundDetectionId.Address).Select(message =>
             {
                 var (tagId, timestamp) = InboundDetectionId.GetTimestampedPayload(message);
                 return Timestamped.Create(new RfidMeasurement(Location, tagId), timestamp);


### PR DESCRIPTION
This PR ensures the `ParseRfidMeasurement` combinator is applied only to messages with the correct register type.