### PR TITLE
Normalize line endings of inputs to label control

### DIFF
--- a/src/Aeon.Environment/Aeon.Environment.csproj
+++ b/src/Aeon.Environment/Aeon.Environment.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Environment</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231012</VersionSuffix>
+    <VersionSuffix>build231013</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Environment/LabelVisualizer.cs
+++ b/src/Aeon.Environment/LabelVisualizer.cs
@@ -17,7 +17,7 @@ namespace Aeon.Environment
         public override void Show(object value)
         {
             value = value ?? string.Empty;
-            textBox.Text = value.ToString();
+            textBox.Text = value.ToString().ReplaceLineEndings();
         }
 
         public override void Load(IServiceProvider provider)

--- a/src/Aeon.Environment/StringExtensions.cs
+++ b/src/Aeon.Environment/StringExtensions.cs
@@ -1,10 +1,22 @@
-﻿namespace Aeon.Environment
+﻿using System.Text.RegularExpressions;
+
+namespace Aeon.Environment
 {
     static class StringExtensions
     {
         public static string AsNullIfEmpty(this string value)
         {
             return !string.IsNullOrEmpty(value) ? value : null;
+        }
+
+        public static string ReplaceLineEndings(this string value)
+        {
+            return ReplaceLineEndings(value, System.Environment.NewLine);
+        }
+
+        public static string ReplaceLineEndings(this string value, string newLine)
+        {
+            return Regex.Replace(value, @"\r\n|\n\r|\n|\r", newLine);
         }
     }
 }


### PR DESCRIPTION
This PR normalizes the line endings of input strings on the visualizer of the `LabelControl` operator to ensure that `TextBox` always renders all multi-line inputs correctly.

Fixes #178 