### PR TITLE
Set specific name for JSON training config file

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>build231011</VersionSuffix>
+    <VersionSuffix>build231012</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/CreatePoseTrackingMetadata.cs
+++ b/src/Aeon.Acquisition/CreatePoseTrackingMetadata.cs
@@ -49,7 +49,7 @@ namespace Aeon.Acquisition
                     nameof(modelPath));
             }
 
-            var jsonConfigFiles = directoryInfo.GetFiles("*.json");
+            var jsonConfigFiles = directoryInfo.GetFiles("confmap_config.json");
             if (jsonConfigFiles.Length != 1)
             {
                 throw new ArgumentException(


### PR DESCRIPTION
This PR fixes a search strategy for finding JSON training config files for SLEAP models, assuming that the config file of interest will always be called `confmap_config.json` no matter how many JSON files are in the model folder.

Fixes #180 