### PR TITLE
Ensure state recovery of random depleted patches

### DIFF
--- a/src/Aeon.Foraging/Aeon.Foraging.csproj
+++ b/src/Aeon.Foraging/Aeon.Foraging.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Foraging</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231011</VersionSuffix>
+    <VersionSuffix>build231012</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Foraging/RandomDepletion.bonsai
+++ b/src/Aeon.Foraging/RandomDepletion.bonsai
@@ -1,26 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.7.1"
+<WorkflowBuilder Version="2.8.0"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
-                 xmlns:aeon-env="clr-namespace:Aeon.Environment;assembly=Aeon.Environment"
-                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:aeon-env="clr-namespace:Aeon.Environment;assembly=Aeon.Environment"
+                 xmlns:scr="clr-namespace:Bonsai.Scripting.Expressions;assembly=Bonsai.Scripting.Expressions"
                  xmlns:p1="clr-namespace:Bonsai.Numerics.Distributions;assembly=Bonsai.Numerics"
                  xmlns="https://bonsai-rx.org/2018/workflow">
   <Description>The patch is replenished using a probabilistic sampling function.</Description>
   <Workflow>
     <Nodes>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="DistanceThreshold" />
-        <Property Name="Rate" />
-        <Property Name="DeliveryCount" />
-      </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="PatchState" />
-      </Expression>
       <Expression xsi:type="WorkflowInput">
         <Name>Source1</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" />
+      </Expression>
+      <Expression xsi:type="aeon:StateRecoverySubject" TypeArguments="sys:Double">
+        <aeon:Name>DistanceState</aeon:Name>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="rx:Take">
+          <rx:Count>1</rx:Count>
+        </Combinator>
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon:PrependOnce" />
       </Expression>
       <Expression xsi:type="GroupWorkflow">
         <Name>MaintenanceGain</Name>
@@ -55,25 +61,19 @@
           <Property Name="Gain" />
         </PropertyMappings>
       </Expression>
-      <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Name" />
-      </Expression>
-      <Expression xsi:type="aeon:StateRecoverySubject" TypeArguments="sys:Double">
-        <aeon:Name>DistanceState</aeon:Name>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="rx:Take">
-          <rx:Count>1</rx:Count>
-        </Combinator>
-      </Expression>
-      <Expression xsi:type="Combinator">
-        <Combinator xsi:type="aeon:PrependOnce" />
-      </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Aeon.Foraging:DistanceTravelled.bonsai">
         <Gain>1</Gain>
       </Expression>
       <Expression xsi:type="MulticastSubject">
         <Name>DistanceState</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="DistanceThreshold" />
+        <Property Name="Rate" />
+        <Property Name="DeliveryCount" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="PatchState" />
       </Expression>
       <Expression xsi:type="GroupWorkflow">
         <Name>SamplingFunction</Name>
@@ -112,6 +112,12 @@
                 <Value>0</Value>
               </Combinator>
             </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Name" DisplayName="DeliveryCount" />
+            </Expression>
+            <Expression xsi:type="aeon:StateRecoverySubject">
+              <Name>DeliveryCount</Name>
+            </Expression>
             <Expression xsi:type="WorkflowInput">
               <Name>Source1</Name>
             </Expression>
@@ -121,58 +127,142 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>PatchState</Name>
             </Expression>
+            <Expression xsi:type="MemberSelector">
+              <Selector>Item1</Selector>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:WithLatestFrom" />
+            </Expression>
+            <Expression xsi:type="scr:ExpressionCondition">
+              <scr:Expression>double.IsNaN(Item2) || Item1 &gt; Item2</scr:Expression>
+            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:Take">
                 <rx:Count>1</rx:Count>
               </Combinator>
             </Expression>
-            <Expression xsi:type="rx:Condition">
+            <Expression xsi:type="rx:SelectMany">
+              <Name>SampleThreshold</Name>
               <Workflow>
                 <Nodes>
                   <Expression xsi:type="WorkflowInput">
                     <Name>Source1</Name>
                   </Expression>
-                  <Expression xsi:type="MemberSelector">
-                    <Selector>Item2</Selector>
+                  <Expression xsi:type="ExternalizedMapping">
+                    <Property Name="Name" />
                   </Expression>
-                  <Expression xsi:type="GreaterThan">
-                    <Operand xsi:type="DoubleProperty">
-                      <Value>0</Value>
-                    </Operand>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>PatchState</Name>
+                  </Expression>
+                  <Expression xsi:type="GroupWorkflow">
+                    <Name>Threshold</Name>
+                    <Workflow>
+                      <Nodes>
+                        <Expression xsi:type="WorkflowInput">
+                          <Name>Source1</Name>
+                        </Expression>
+                        <Expression xsi:type="WorkflowOutput" />
+                      </Nodes>
+                      <Edges>
+                        <Edge From="0" To="1" Label="Source1" />
+                      </Edges>
+                    </Workflow>
+                  </Expression>
+                  <Expression xsi:type="SubscribeSubject">
+                    <Name>Random</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:CombineLatest" />
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Take">
+                      <rx:Count>1</rx:Count>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="scr:ExpressionTransform">
+                    <scr:Expression>new(
+Item1.Item2 as D0,
+Item1.Item3 as Rate,
+Item2 as Random)</scr:Expression>
+                  </Expression>
+                  <Expression xsi:type="InputMapping">
+                    <PropertyMappings>
+                      <Property Name="Rate" Selector="Rate" />
+                    </PropertyMappings>
+                    <Selector>Random</Selector>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="p1:CreateExponential">
+                      <p1:Rate>100</p1:Rate>
+                    </Combinator>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Zip" />
+                  </Expression>
+                  <Expression xsi:type="scr:ExpressionTransform">
+                    <scr:Expression>new(
+Item2.Sample() + Item1.D0 as Threshold,
+Item1.D0 as D0,
+Item1.Rate as Rate)</scr:Expression>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Threshold,D0,Rate</Selector>
+                    <TypeMapping xsi:type="TypeMapping" TypeArguments="sys:ValueTuple(sys:Double,sys:Double,sys:Double)" />
+                  </Expression>
+                  <Expression xsi:type="MulticastSubject">
+                    <Name>PatchState</Name>
+                  </Expression>
+                  <Expression xsi:type="Combinator">
+                    <Combinator xsi:type="rx:Sample" />
+                  </Expression>
+                  <Expression xsi:type="scr:ExpressionCondition">
+                    <scr:Expression>!double.IsNaN(Item2)</scr:Expression>
                   </Expression>
                   <Expression xsi:type="WorkflowOutput" />
                 </Nodes>
                 <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="0" To="14" Label="Source1" />
                   <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="1" To="13" Label="Source2" />
                   <Edge From="2" To="3" Label="Source1" />
+                  <Edge From="3" To="5" Label="Source1" />
+                  <Edge From="4" To="5" Label="Source2" />
+                  <Edge From="5" To="6" Label="Source1" />
+                  <Edge From="6" To="7" Label="Source1" />
+                  <Edge From="7" To="8" Label="Source1" />
+                  <Edge From="7" To="10" Label="Source1" />
+                  <Edge From="8" To="9" Label="Source1" />
+                  <Edge From="9" To="10" Label="Source2" />
+                  <Edge From="10" To="11" Label="Source1" />
+                  <Edge From="11" To="12" Label="Source1" />
+                  <Edge From="12" To="13" Label="Source1" />
+                  <Edge From="13" To="14" Label="Source2" />
+                  <Edge From="14" To="15" Label="Source1" />
+                  <Edge From="15" To="16" Label="Source1" />
                 </Edges>
               </Workflow>
             </Expression>
-            <Expression xsi:type="PropertyMapping">
-              <PropertyMappings>
-                <Property Name="Value" Selector="Item3" />
-              </PropertyMappings>
-            </Expression>
-            <Expression xsi:type="ExternalizedMapping">
-              <Property Name="Name" DisplayName="DeliveryCount" />
-            </Expression>
-            <Expression xsi:type="aeon:StateRecoverySubject">
-              <Name>DeliveryCount</Name>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="IntProperty">
+                <Value>1</Value>
+              </Combinator>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>DeliveryCount</Name>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>DeliveryCount</Name>
-            </Expression>
-            <Expression xsi:type="ExternalizedMapping">
-              <Property Name="Value" DisplayName="Rate" />
             </Expression>
             <Expression xsi:type="Combinator">
-              <Combinator xsi:type="DoubleProperty">
-                <Value>0.01</Value>
-              </Combinator>
+              <Combinator xsi:type="rx:WithLatestFrom" />
+            </Expression>
+            <Expression xsi:type="Add" />
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Repeat" />
+            </Expression>
+            <Expression xsi:type="MulticastSubject">
+              <Name>DeliveryCount</Name>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" DisplayName="DistanceThreshold" Description="The minimum distance required to obtain a pellet." />
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>PatchState</Name>
@@ -210,12 +300,53 @@
                 <Property Name="Value" Selector="Item2" />
               </PropertyMappings>
             </Expression>
-            <Expression xsi:type="ExternalizedMapping">
-              <Property Name="Value" DisplayName="DistanceThreshold" Description="The minimum distance required to obtain a pellet." />
-            </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="DoubleProperty">
                 <Value>75</Value>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" DisplayName="Rate" />
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>PatchState</Name>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:Take">
+                <rx:Count>1</rx:Count>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:Condition">
+              <Workflow>
+                <Nodes>
+                  <Expression xsi:type="WorkflowInput">
+                    <Name>Source1</Name>
+                  </Expression>
+                  <Expression xsi:type="MemberSelector">
+                    <Selector>Item2</Selector>
+                  </Expression>
+                  <Expression xsi:type="GreaterThan">
+                    <Operand xsi:type="DoubleProperty">
+                      <Value>0</Value>
+                    </Operand>
+                  </Expression>
+                  <Expression xsi:type="WorkflowOutput" />
+                </Nodes>
+                <Edges>
+                  <Edge From="0" To="1" Label="Source1" />
+                  <Edge From="1" To="2" Label="Source1" />
+                  <Edge From="2" To="3" Label="Source1" />
+                </Edges>
+              </Workflow>
+            </Expression>
+            <Expression xsi:type="PropertyMapping">
+              <PropertyMappings>
+                <Property Name="Value" Selector="Item3" />
+              </PropertyMappings>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="DoubleProperty">
+                <Value>0.01</Value>
               </Combinator>
             </Expression>
             <Expression xsi:type="Combinator">
@@ -237,114 +368,6 @@ Item1.Item2 as Rate)</scr:Expression>
               <Selector>Threshold,D0,Rate</Selector>
               <TypeMapping xsi:type="TypeMapping" TypeArguments="sys:ValueTuple(sys:Double,sys:Double,sys:Double)" />
             </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>PatchState</Name>
-            </Expression>
-            <Expression xsi:type="GroupWorkflow">
-              <Name>Threshold</Name>
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>Random</Name>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:CombineLatest" />
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="scr:ExpressionTransform">
-              <scr:Expression>new(
-Item1.Item2 as D0,
-Item1.Item3 as Rate,
-Item3 as Random)</scr:Expression>
-            </Expression>
-            <Expression xsi:type="InputMapping">
-              <PropertyMappings>
-                <Property Name="Rate" Selector="Rate" />
-              </PropertyMappings>
-              <Selector>Random</Selector>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="p1:CreateExponential">
-                <p1:Rate>100</p1:Rate>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Zip" />
-            </Expression>
-            <Expression xsi:type="scr:ExpressionTransform">
-              <scr:Expression>new(
-Item2.Sample() + Item1.D0 as Threshold,
-Item1.D0 as D0,
-Item1.Rate as Rate)</scr:Expression>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Threshold,D0,Rate</Selector>
-              <TypeMapping xsi:type="TypeMapping" TypeArguments="sys:ValueTuple(sys:Double,sys:Double,sys:Double)" />
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>PatchState</Name>
-            </Expression>
-            <Expression xsi:type="MemberSelector">
-              <Selector>Item1</Selector>
-            </Expression>
-            <Expression xsi:type="PropertyMapping">
-              <PropertyMappings>
-                <Property Name="Value" />
-              </PropertyMappings>
-            </Expression>
-            <Expression xsi:type="GreaterThan">
-              <Operand xsi:type="DoubleProperty">
-                <Value>50.004432094988864</Value>
-              </Operand>
-            </Expression>
-            <Expression xsi:type="rx:Condition">
-              <Workflow>
-                <Nodes>
-                  <Expression xsi:type="WorkflowInput">
-                    <Name>Source1</Name>
-                  </Expression>
-                  <Expression xsi:type="WorkflowOutput" />
-                </Nodes>
-                <Edges>
-                  <Edge From="0" To="1" Label="Source1" />
-                </Edges>
-              </Workflow>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Take">
-                <rx:Count>1</rx:Count>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="IntProperty">
-                <Value>1</Value>
-              </Combinator>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:WithLatestFrom" />
-            </Expression>
-            <Expression xsi:type="Add" />
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:Repeat" />
-            </Expression>
-            <Expression xsi:type="MulticastSubject">
-              <Name>DeliveryCount</Name>
-            </Expression>
-            <Expression xsi:type="WorkflowOutput" />
             <Expression xsi:type="MulticastSubject">
               <Name>PatchState</Name>
             </Expression>
@@ -352,78 +375,64 @@ Item1.Rate as Rate)</scr:Expression>
           <Edges>
             <Edge From="0" To="1" Label="Source1" />
             <Edge From="1" To="2" Label="Source1" />
-            <Edge From="2" To="10" Label="Source1" />
-            <Edge From="3" To="40" Label="Source1" />
-            <Edge From="4" To="37" Label="Source2" />
-            <Edge From="4" To="5" Label="Source1" />
-            <Edge From="4" To="15" Label="Source1" />
-            <Edge From="4" To="22" Label="Source1" />
-            <Edge From="4" To="26" Label="Source1" />
-            <Edge From="4" To="49" Label="Source2" />
-            <Edge From="5" To="6" Label="Source1" />
+            <Edge From="2" To="4" Label="Source1" />
+            <Edge From="3" To="4" Label="Source2" />
+            <Edge From="3" To="14" Label="Source1" />
+            <Edge From="3" To="18" Label="Source2" />
+            <Edge From="5" To="9" Label="Source1" />
             <Edge From="6" To="7" Label="Source1" />
+            <Edge From="6" To="12" Label="Source2" />
+            <Edge From="6" To="21" Label="Source1" />
+            <Edge From="6" To="27" Label="Source1" />
+            <Edge From="6" To="33" Label="Source1" />
+            <Edge From="6" To="37" Label="Source2" />
             <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="14" Label="Source2" />
-            <Edge From="9" To="47" Label="Source2" />
-            <Edge From="9" To="10" Label="Source2" />
-            <Edge From="9" To="11" Label="Source1" />
-            <Edge From="9" To="12" Label="Source1" />
-            <Edge From="11" To="29" Label="Source2" />
-            <Edge From="12" To="44" Label="Source2" />
-            <Edge From="13" To="14" Label="Source1" />
-            <Edge From="14" To="21" Label="Source2" />
+            <Edge From="8" To="9" Label="Source2" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
+            <Edge From="11" To="12" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="13" To="15" Label="Source1" />
+            <Edge From="14" To="15" Label="Source2" />
             <Edge From="15" To="16" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
             <Edge From="17" To="18" Label="Source1" />
-            <Edge From="18" To="20" Label="Source2" />
-            <Edge From="19" To="20" Label="Source1" />
-            <Edge From="20" To="21" Label="Source1" />
-            <Edge From="21" To="23" Label="Source1" />
-            <Edge From="22" To="23" Label="Source2" />
+            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="20" To="25" Label="Source1" />
+            <Edge From="21" To="22" Label="Source1" />
+            <Edge From="22" To="23" Label="Source1" />
             <Edge From="23" To="24" Label="Source1" />
-            <Edge From="24" To="25" Label="Source1" />
-            <Edge From="25" To="49" Label="Source1" />
-            <Edge From="26" To="27" Label="Source1" />
-            <Edge From="27" To="29" Label="Source1" />
-            <Edge From="28" To="29" Label="Source3" />
+            <Edge From="24" To="25" Label="Source2" />
+            <Edge From="25" To="32" Label="Source1" />
+            <Edge From="26" To="31" Label="Source1" />
+            <Edge From="27" To="28" Label="Source1" />
+            <Edge From="28" To="29" Label="Source1" />
             <Edge From="29" To="30" Label="Source1" />
-            <Edge From="30" To="31" Label="Source1" />
-            <Edge From="31" To="34" Label="Source1" />
-            <Edge From="31" To="32" Label="Source1" />
-            <Edge From="32" To="33" Label="Source1" />
+            <Edge From="30" To="31" Label="Source2" />
+            <Edge From="31" To="32" Label="Source2" />
+            <Edge From="32" To="34" Label="Source1" />
             <Edge From="33" To="34" Label="Source2" />
             <Edge From="34" To="35" Label="Source1" />
             <Edge From="35" To="36" Label="Source1" />
             <Edge From="36" To="37" Label="Source1" />
-            <Edge From="37" To="38" Label="Source1" />
-            <Edge From="38" To="39" Label="Source1" />
-            <Edge From="39" To="40" Label="Source2" />
-            <Edge From="40" To="41" Label="Source1" />
-            <Edge From="41" To="42" Label="Source1" />
-            <Edge From="42" To="43" Label="Source1" />
-            <Edge From="43" To="44" Label="Source1" />
-            <Edge From="44" To="45" Label="Source1" />
-            <Edge From="45" To="46" Label="Source1" />
-            <Edge From="46" To="47" Label="Source1" />
-            <Edge From="47" To="48" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="11" Label="Source2" />
-      <Edge From="1" To="11" Label="Source3" />
-      <Edge From="2" To="8" Label="Source1" />
-      <Edge From="3" To="4" Label="Source1" />
-      <Edge From="4" To="9" Label="Source2" />
+      <Edge From="0" To="4" Label="Source1" />
+      <Edge From="1" To="2" Label="Source1" />
+      <Edge From="1" To="8" Label="Source2" />
+      <Edge From="2" To="3" Label="Source1" />
+      <Edge From="3" To="4" Label="Source2" />
+      <Edge From="4" To="7" Label="Source1" />
       <Edge From="5" To="6" Label="Source1" />
-      <Edge From="5" To="10" Label="Source2" />
-      <Edge From="6" To="7" Label="Source1" />
-      <Edge From="7" To="8" Label="Source2" />
-      <Edge From="8" To="9" Label="Source1" />
-      <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="6" To="7" Label="Source2" />
+      <Edge From="7" To="8" Label="Source1" />
+      <Edge From="8" To="11" Label="Source1" />
+      <Edge From="9" To="11" Label="Source2" />
+      <Edge From="10" To="11" Label="Source3" />
       <Edge From="11" To="12" Label="Source1" />
     </Edges>
   </Workflow>


### PR DESCRIPTION
This PR rewrites the threshold sampling logic of the random depletion operator to allow for correct state recovery behavior. Previously, a new threshold was sampled on every new subscription following a threshold crossing, including the first subscription when an existing threshold value might be pulled from the state recovery subject.

The rewrite places the sampling logic always following evaluation of threshold crossing. This ensures that recovered thresholds are pulled and used verbatim from persistent storage. The special case of the very first threshold crossing in a period or epoch is handled by using `NaN` to denote the initial threshold value. In this case, the threshold crossing condition accepts any wheel value, and a new threshold is resampled, but crucially the actual event giving rise to a pellet delivery is rejected.

This effectively creates a first "dummy" trial consisting of a single sample that immediately triggers a new threshold only for the very first pellet. The workflow was tested in a simulated environment consisting of a fully corrected patch block logic.

Fixes #184 