### PR TITLE
Add simulated video source module

### DIFF
--- a/src/Aeon.Acquisition/FileVideoSource.bonsai
+++ b/src/Aeon.Acquisition/FileVideoSource.bonsai
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<WorkflowBuilder Version="2.8.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
+                 xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
+                 xmlns:sys="clr-namespace:System;assembly=mscorlib"
+                 xmlns="https://bonsai-rx.org/2018/workflow">
+  <Description>Provides a video module simulated from a file for testing and debugging of environments with video pipelines.</Description>
+  <Workflow>
+    <Nodes>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="TriggerSource" Description="The PWM trigger source used to drive the camera." />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject">
+        <Name>GlobalTrigger</Name>
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="FileName" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon:VideoFileCapture" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="FrameEvents" Description="The name of the output sequence containing all frame events from the video source." />
+      </Expression>
+      <Expression xsi:type="rx:PublishSubject">
+        <Name>FrameEvents</Name>
+      </Expression>
+      <Expression xsi:type="WorkflowOutput" />
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Name" DisplayName="TriggerFrequency" Description="The frequency of the trigger source." />
+      </Expression>
+      <Expression xsi:type="SubscribeSubject" TypeArguments="sys:Double">
+        <Name>GlobalTriggerFrequency</Name>
+      </Expression>
+    </Nodes>
+    <Edges>
+      <Edge From="0" To="1" Label="Source1" />
+      <Edge From="1" To="3" Label="Source1" />
+      <Edge From="2" To="3" Label="Source2" />
+      <Edge From="3" To="5" Label="Source1" />
+      <Edge From="4" To="5" Label="Source2" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="7" To="8" Label="Source1" />
+    </Edges>
+  </Workflow>
+</WorkflowBuilder>

--- a/src/Aeon.Acquisition/VideoFileCapture.cs
+++ b/src/Aeon.Acquisition/VideoFileCapture.cs
@@ -15,15 +15,11 @@ namespace Aeon.Acquisition
     {
         [Description("The path to the file used to source the video frames.")]
         [Editor("Bonsai.Design.OpenFileNameEditor, Bonsai.Design", DesignTypes.UITypeEditor)]
-        public string Path { get; set; }
-
-        [Description("Specifies the color conversion to use when reading the video frames.")]
-        public ColorConversion? ColorConversion { get; set; } = OpenCV.Net.ColorConversion.Bgr2Gray;
+        public string FileName { get; set; }
 
         public override IObservable<Timestamped<VideoDataFrame>> Generate()
         {
-            var videoFileName = Path;
-            var colorConversion = ColorConversion;
+            var videoFileName = FileName;
             if (string.IsNullOrEmpty(videoFileName))
             {
                 throw new InvalidOperationException("A valid file name must be specified");
@@ -31,8 +27,9 @@ namespace Aeon.Acquisition
 
             return Observable.Defer(() =>
             {
+                var grayscale = new Grayscale();
                 var capture = new FileCapture { FileName = videoFileName };
-                var metadataFileName = System.IO.Path.ChangeExtension(videoFileName, ".csv");
+                var metadataFileName = Path.ChangeExtension(videoFileName, ".csv");
                 var metadataContents = File.ReadAllLines(metadataFileName).Skip(1).Select(row =>
                 {
                     var values = row.Split(',');
@@ -49,13 +46,7 @@ namespace Aeon.Acquisition
                 }).ToArray();
 
                 var frames = capture.Generate();
-                if (colorConversion.HasValue)
-                {
-                    var convertColor = new ConvertColor { Conversion = colorConversion.GetValueOrDefault() };
-                    frames = convertColor.Process(frames);
-                }
-                
-                return frames.Select((frame, index) =>
+                return grayscale.Process(frames).Select((frame, index) =>
                 {
                     var (seconds, frameID, frameTimestamp) = metadataContents[index];
                     var dataFrame = new VideoDataFrame(frame, frameID, frameTimestamp);
@@ -66,28 +57,34 @@ namespace Aeon.Acquisition
 
         public IObservable<Timestamped<VideoDataFrame>> Generate<TPayload>(IObservable<Timestamped<TPayload>> source)
         {
-            var videoFileName = Path;
-            var colorConversion = ColorConversion;
+            var videoFileName = FileName;
             if (string.IsNullOrEmpty(videoFileName))
             {
                 throw new InvalidOperationException("A valid file name must be specified");
             }
 
+            const string ImageExtensions = ".png;.bmp;.jpg;.jpeg;.tif;.tiff;.exr";
+            var extension = Path.GetExtension(videoFileName);
             return source.Publish(trigger =>
             {
-                var capture = new FileCapture { FileName = videoFileName };
-                var frames = capture.Generate(trigger);
-                if (colorConversion.HasValue)
+                var frameID = 0L;
+                Timestamped<VideoDataFrame> TimestampFrame(Timestamped<TPayload> timestamped, IplImage frame)
                 {
-                    var convertColor = new ConvertColor { Conversion = colorConversion.GetValueOrDefault() };
-                    frames = convertColor.Process(frames);
+                    var dataFrame = new VideoDataFrame(frame, frameID++, (long)(timestamped.Seconds * 1e6));
+                    return Timestamped.Create(dataFrame, timestamped.Seconds);
                 }
 
-                return trigger.Zip(frames, (timestamped, frame) =>
+                if (!string.IsNullOrEmpty(extension) && ImageExtensions.Contains(extension))
                 {
-                    var dataFrame = new VideoDataFrame(frame, 9, (long)(timestamped.Seconds * 1e6));
-                    return Timestamped.Create(dataFrame, timestamped.Seconds);
-                });
+                    var capture = new LoadImage { FileName = videoFileName, Mode = LoadImageFlags.Grayscale };
+                    return trigger.CombineLatest(capture.Generate(), TimestampFrame);
+                }
+                else
+                {
+                    var grayscale = new Grayscale();
+                    var capture = new FileCapture { FileName = videoFileName, Loop = true };
+                    return trigger.Zip(grayscale.Process(capture.Generate(trigger)), TimestampFrame);
+                }
             });
         }
     }


### PR DESCRIPTION
This PR adds a new simulated video source module to allow testing and debugging of environments with video pipelines by sampling frames from either a video or image file using a timestamped trigger source.

In the case of a video file, the file is set to loop to ensure a potentially infinite video sequence. In the case of a static image, the same frame is cached and sent repeatedly to minimize resource usage.