### PR TITLE
Support formatting value sequences as JSON strings

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="LibGit2Sharp" Version="0.25.4" />
     <PackageReference Include="Bonsai.Vision" Version="2.8.0" />
     <PackageReference Include="Bonsai.Numerics" Version="0.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Aeon.Acquisition/FormatJson.cs
+++ b/src/Aeon.Acquisition/FormatJson.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using Bonsai;
+using Newtonsoft.Json;
+
+namespace Aeon.Acquisition
+{
+    [Combinator]
+    [Description("Formats a sequence of values into a sequence of JSON strings.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class FormatJson
+    {
+        public IObservable<string> Process<TSource>(IObservable<TSource> source)
+        {
+            return source.Select(value => JsonConvert.SerializeObject(value));
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new operator `FormatJson` which allows formatting an arbitrary sequence of values into JSON. It can be used as the basis for logging environment state schemas computed and timestamped at runtime using the JSON lines specification to support chunking.