### PR TITLE
Set default camel case naming strategy

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>build231203</VersionSuffix>
+    <VersionSuffix>build231204</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/FormatJson.cs
+++ b/src/Aeon.Acquisition/FormatJson.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using Bonsai;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Aeon.Acquisition
 {
@@ -12,9 +13,17 @@ namespace Aeon.Acquisition
     [WorkflowElementCategory(ElementCategory.Transform)]
     public class FormatJson
     {
+        static readonly JsonSerializerSettings DefaultSettings = new()
+        {
+            ContractResolver = new DefaultContractResolver
+            {
+                NamingStrategy = new CamelCaseNamingStrategy()
+            }
+        };
+
         public IObservable<string> Process<TSource>(IObservable<TSource> source)
         {
-            return source.Select(value => JsonConvert.SerializeObject(value));
+            return source.Select(value => JsonConvert.SerializeObject(value, DefaultSettings));
         }
     }
 }


### PR DESCRIPTION
This PR sets the default naming strategy for `FormatJson` to camel case for consistency with common JSON schema usage.