### PR TITLE
Add labeled button UI element

### DIFF
--- a/src/Aeon.Environment/Aeon.Environment.csproj
+++ b/src/Aeon.Environment/Aeon.Environment.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Environment</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231015</VersionSuffix>
+    <VersionSuffix>build231208</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Environment/Aeon.Environment.csproj.user
+++ b/src/Aeon.Environment/Aeon.Environment.csproj.user
@@ -5,6 +5,9 @@
     <Compile Update="AnnotationControl.cs">
       <SubType>UserControl</SubType>
     </Compile>
+    <Compile Update="ButtonControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
     <Compile Update="EnvironmentStateControl.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/src/Aeon.Environment/ButtonControl.Designer.cs
+++ b/src/Aeon.Environment/ButtonControl.Designer.cs
@@ -1,0 +1,80 @@
+﻿namespace Aeon.Environment
+{
+    partial class ButtonControl
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.buttonPanel = new System.Windows.Forms.Panel();
+            this.button = new System.Windows.Forms.Button();
+            this.buttonPanel.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // buttonPanel
+            // 
+            this.buttonPanel.Controls.Add(this.button);
+            this.buttonPanel.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.buttonPanel.Location = new System.Drawing.Point(0, 0);
+            this.buttonPanel.Margin = new System.Windows.Forms.Padding(6);
+            this.buttonPanel.Name = "buttonPanel";
+            this.buttonPanel.Size = new System.Drawing.Size(400, 240);
+            this.buttonPanel.TabIndex = 10;
+            // 
+            // button
+            // 
+            this.button.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.button.Location = new System.Drawing.Point(6, 6);
+            this.button.Margin = new System.Windows.Forms.Padding(6);
+            this.button.Name = "button";
+            this.button.Size = new System.Drawing.Size(388, 228);
+            this.button.TabIndex = 0;
+            this.button.Text = "Button";
+            this.button.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.button.UseVisualStyleBackColor = true;
+            this.button.Click += new System.EventHandler(this.button_Click);
+            // 
+            // ButtonControl
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(16F, 31F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.buttonPanel);
+            this.Font = new System.Drawing.Font("Microsoft Sans Serif", 16.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.Margin = new System.Windows.Forms.Padding(6);
+            this.Name = "ButtonControl";
+            this.Size = new System.Drawing.Size(400, 240);
+            this.buttonPanel.ResumeLayout(false);
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel buttonPanel;
+        private System.Windows.Forms.Button button;
+    }
+}

--- a/src/Aeon.Environment/ButtonControl.cs
+++ b/src/Aeon.Environment/ButtonControl.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Reactive;
+using System.Windows.Forms;
+
+namespace Aeon.Environment
+{
+    partial class ButtonControl : UserControl
+    {
+        public ButtonControl(ButtonSource source)
+        {
+            Source = source ?? throw new ArgumentNullException(nameof(source));
+            InitializeComponent();
+            var text = Source.Text;
+            if (!string.IsNullOrEmpty(text))
+            {
+                button.Text = text;
+            }
+        }
+
+        public ButtonSource Source { get; }
+
+        private void button_Click(object sender, EventArgs e)
+        {
+            Source.OnNext(Unit.Default);
+        }
+    }
+}

--- a/src/Aeon.Environment/ButtonControl.cs
+++ b/src/Aeon.Environment/ButtonControl.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Reactive;
 using System.Windows.Forms;
 
 namespace Aeon.Environment
@@ -21,7 +20,7 @@ namespace Aeon.Environment
 
         private void button_Click(object sender, EventArgs e)
         {
-            Source.OnNext(Unit.Default);
+            Source.OnNext(button.Text);
         }
     }
 }

--- a/src/Aeon.Environment/ButtonControl.resx
+++ b/src/Aeon.Environment/ButtonControl.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/Aeon.Environment/ButtonSource.cs
+++ b/src/Aeon.Environment/ButtonSource.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel;
+using System.Reactive;
+using Aeon.Acquisition;
+using Bonsai;
+
+namespace Aeon.Environment
+{
+    [TypeVisualizer(typeof(ButtonSourceVisualizer))]
+    [Description("Provides a labeled button control generating a sequence of events for each button click.")]
+    public class ButtonSource : MetadataSource<Unit>
+    {
+        [Description("Specifies the text associated with this button.")]
+        public string Text { get; set; }
+    }
+}

--- a/src/Aeon.Environment/ButtonSource.cs
+++ b/src/Aeon.Environment/ButtonSource.cs
@@ -1,5 +1,4 @@
 ﻿using System.ComponentModel;
-using System.Reactive;
 using Aeon.Acquisition;
 using Bonsai;
 
@@ -7,7 +6,7 @@ namespace Aeon.Environment
 {
     [TypeVisualizer(typeof(ButtonSourceVisualizer))]
     [Description("Provides a labeled button control generating a sequence of events for each button click.")]
-    public class ButtonSource : MetadataSource<Unit>
+    public class ButtonSource : MetadataSource<string>
     {
         [Description("Specifies the text associated with this button.")]
         public string Text { get; set; }

--- a/src/Aeon.Environment/ButtonSourceVisualizer.cs
+++ b/src/Aeon.Environment/ButtonSourceVisualizer.cs
@@ -1,0 +1,41 @@
+﻿using Bonsai.Design;
+using Bonsai.Expressions;
+using System;
+using System.Windows.Forms;
+
+namespace Aeon.Environment
+{
+    public class ButtonSourceVisualizer : DialogTypeVisualizer
+    {
+        ButtonControl control;
+
+        public override void Load(IServiceProvider provider)
+        {
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var visualizerElement = ExpressionBuilder.GetVisualizerElement(context.Source);
+            var source = (ButtonSource)ExpressionBuilder.GetWorkflowElement(visualizerElement.Builder);
+
+            control = new ButtonControl(source);
+            control.Dock = DockStyle.Fill;
+
+            var visualizerService = (IDialogTypeVisualizerService)provider.GetService(typeof(IDialogTypeVisualizerService));
+            if (visualizerService != null)
+            {
+                visualizerService.AddControl(control);
+            }
+        }
+
+        public override void Show(object value)
+        {
+        }
+
+        public override void Unload()
+        {
+            if (control != null)
+            {
+                control.Dispose();
+                control = null;
+            }
+        }
+    }
+}

--- a/src/Aeon.Environment/TareWeightVisualizer.cs
+++ b/src/Aeon.Environment/TareWeightVisualizer.cs
@@ -1,8 +1,6 @@
 ﻿using Bonsai.Design;
 using Bonsai.Expressions;
 using System;
-using System.Drawing;
-using System.Reactive;
 using System.Windows.Forms;
 
 namespace Aeon.Environment


### PR DESCRIPTION
This PR introduces a more flexible labeled button UI element to use in experimental workflows to trigger manual actions. The text specified in the button label is included with the click event notification to allow differential processing of presses across different buttons, e.g. by grouping based on prefix, or extracting button IDs.