### PR TITLE
Add property grid view configuration properties

### DIFF
--- a/src/Aeon.Environment/Aeon.Environment.csproj
+++ b/src/Aeon.Environment/Aeon.Environment.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Environment</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231208</VersionSuffix>
+    <VersionSuffix>build231209</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Environment/ExperimentProperties.cs
+++ b/src/Aeon.Environment/ExperimentProperties.cs
@@ -1,10 +1,17 @@
 ﻿using Bonsai;
 using Bonsai.Expressions;
+using System.ComponentModel;
 
 namespace Aeon.Environment
 {
     [TypeVisualizer(typeof(ExternalizedPropertiesVisualizer))]
+    [Description("Provides a configurable visualizer for global workflow properties.")]
     public class ExperimentProperties : UnitBuilder
     {
+        [Description("Specifies whether the help text box is visible.")]
+        public bool HelpVisible { get; set; } = true;
+
+        [Description("Specifies whether the toolbar is visible.")]
+        public bool ToolbarVisible { get; set; } = true;
     }
 }

--- a/src/Aeon.Environment/ExperimentPropertiesVisualizer.cs
+++ b/src/Aeon.Environment/ExperimentPropertiesVisualizer.cs
@@ -1,5 +1,6 @@
 ﻿using Bonsai;
 using Bonsai.Design;
+using Bonsai.Expressions;
 using System;
 using System.Drawing;
 
@@ -12,8 +13,13 @@ namespace Aeon.Environment
         public override void Load(IServiceProvider provider)
         {
             var workflowBuilder = (WorkflowBuilder)provider.GetService(typeof(WorkflowBuilder));
+            var context = (ITypeVisualizerContext)provider.GetService(typeof(ITypeVisualizerContext));
+            var visualizerElement = ExpressionBuilder.GetVisualizerElement(context.Source);
+            var source = (ExperimentProperties)ExpressionBuilder.GetWorkflowElement(visualizerElement.Builder);
 
             control = new PropertyGrid();
+            control.HelpVisible = source.HelpVisible;
+            control.ToolbarVisible = source.ToolbarVisible;
             control.Font = new Font(control.Font.FontFamily, 16.2F);
             control.Dock = System.Windows.Forms.DockStyle.Fill;
             control.SelectedObject = workflowBuilder.Workflow;


### PR DESCRIPTION
This PR extends the property grid visualizer with optional configuration properties allowing to enable or disable specific parts of the grid. This will allow saving space when designing dense experiment control panels, or combining the grid view with other controls, such as buttons or other panels.