### PR TITLE
Clear numeric up down on dispenser events

### DIFF
--- a/src/Aeon.Foraging/Aeon.Foraging.csproj
+++ b/src/Aeon.Foraging/Aeon.Foraging.csproj
@@ -7,7 +7,7 @@
     <PackageTags>Bonsai Rx Project Aeon Foraging</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.1.0</VersionPrefix>
-    <VersionSuffix>build231201</VersionSuffix>
+    <VersionSuffix>build231202</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Foraging/DispenserEventControl.cs
+++ b/src/Aeon.Foraging/DispenserEventControl.cs
@@ -48,8 +48,12 @@ namespace Aeon.Foraging
 
         private void OnDispenserEvent(decimal value, DispenserEventType eventType)
         {
-            var metadata = new DispenserEventArgs((int)value, eventType);
-            Source.OnNext(metadata);
+            if (value != 0)
+            {
+                var metadata = new DispenserEventArgs((int)value, eventType);
+                Source.OnNext(metadata);
+                refillUpDown.Value = 0;
+            }
         }
     }
 }


### PR DESCRIPTION
This PR ensures the numeric up down is cleared on `DispenserEventControl` after issuing a dispenser action, e.g. refill or reset. Furthermore, we introduced a condition where actions are only sent for non-zero values to avoid accidentally repeating commands.

Fixes https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/113