### PR TITLE
Expose static date time conversion method

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>build231205</VersionSuffix>
+    <VersionSuffix>build240101</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/GetDateTime.cs
+++ b/src/Aeon.Acquisition/GetDateTime.cs
@@ -12,7 +12,7 @@ namespace Aeon.Acquisition
     [Description("Converts a sequence of referenced Harp timestamps into system date-time objects.")]
     public class GetDateTime
     {
-        static DateTime FromSeconds(double seconds)
+        public static DateTime FromSeconds(double seconds)
         {
             return GroupByTime.ReferenceTime.AddSeconds(seconds);
         }


### PR DESCRIPTION
This PR exposes the internal static date time conversion function so it can be used in external scripts to convert Harp timestamps to local clock reference time.