### PR TITLE
Update package project URL

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>Sainsbury Wellcome Centre</Authors>
     <Copyright>Copyright © 2023 University College London</Copyright>
-    <PackageProjectUrl>https://github.com/SainsburyWellcomeCentre/aeon_blog</PackageProjectUrl>
+    <PackageProjectUrl>https://sainsburywellcomecentre.github.io/aeon_docs/</PackageProjectUrl>
     <RepositoryUrl>https://github.com/SainsburyWellcomeCentre/aeon_acquisition.git</RepositoryUrl>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
This PR updates the package project URL on all projects to point to the current docs website. All future releases of Aeon packages will be deployed with the updated metadata.