### PR TITLE
Short commit hash should use prefix not suffix

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -6,7 +6,7 @@
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
     <VersionPrefix>0.5.0</VersionPrefix>
-    <VersionSuffix>build240101</VersionSuffix>
+    <VersionSuffix>build240102</VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Acquisition/GetDataPath.cs
+++ b/src/Aeon.Acquisition/GetDataPath.cs
@@ -38,7 +38,7 @@ namespace Aeon.Acquisition
                 else
                 {
                     var commitSha = repo.Head.Tip.Sha;
-                    var shortSha = commitSha.Substring(commitSha.Length - 7);
+                    var shortSha = commitSha.Substring(0, 7);
                     var name = repo.Info.IsHeadDetached
                         ? $"detached-{shortSha}"
                         : $"{repo.Head.FriendlyName}-{shortSha}";


### PR DESCRIPTION
This PR fixes short commit hash generation, which should use the first characters from the full commit hash rather than the last.