### PR TITLE
Delete state recovery temp files after recovery

### DIFF
--- a/src/Aeon.Acquisition/StateRecovery.cs
+++ b/src/Aeon.Acquisition/StateRecovery.cs
@@ -33,6 +33,10 @@ namespace Aeon.Acquisition
             {
                 return new TState();
             }
+            finally
+            {
+                File.Delete(fileName);
+            }
         }
     }
 }


### PR DESCRIPTION
To ensure state recovery temp files do not persist longer than strictly necessary, this PR asserts the deletion of all temp files immediately upon successful (or exceptional) recovery.