### PR TITLE
Ensure all state recovery changes are serialized

### DIFF
--- a/src/Aeon.Acquisition/StateRecoverySubject.cs
+++ b/src/Aeon.Acquisition/StateRecoverySubject.cs
@@ -2,6 +2,7 @@
 using System;
 using System.ComponentModel;
 using System.Linq.Expressions;
+using System.Reactive.Linq;
 using System.Reactive.Subjects;
 
 namespace Aeon.Acquisition
@@ -39,10 +40,8 @@ namespace Aeon.Acquisition
             {
                 var state = StateRecovery<T>.Deserialize(name);
                 subject = new BehaviorSubject<T>(state);
-                Name = name;
+                subject.Skip(1).Subscribe(value => StateRecovery<T>.Serialize(name, value));
             }
-
-            string Name { get; }
 
             public void OnCompleted()
             {
@@ -64,7 +63,6 @@ namespace Aeon.Acquisition
 
             public void Dispose()
             {
-                StateRecovery<T>.Serialize(Name, subject.Value);
                 subject.Dispose();
             }
         }


### PR DESCRIPTION
## Summary

The original implementation for `StateRecoverySubject` serialized the changes only on `Dispose`. This PR changes these semantics to instead serialize all changes as soon as they are received by the subject.

## Motivation

The purpose of `StateRecoverySubject` is to allow persistence of environment logic state when the workflow needs to be stopped for maintenance or in case of an unhandled exception. To minimize file IO, the previous implementation only serialized the state on subject disposal, which under normal situations will always happen either on successful or exceptional termination of the workflow.

However, this does not account for situations where the process itself might terminate abnormally in a non-recoverable way, e.g. BSOD, forceful termination of the process by either the OS or the user, or stack overflow exceptions.

## Proposed Design

This PR modifies the behavior of `StateRecoverySubject` by ensuring that all changes to the persistent state are serialized to disk immediately upon reception of the notification.

## Drawbacks

This proposal will significantly increase the pressure on disk for high-frequency state changes. The current implementation is not optimized for streaming, so files are deleted, overwritten and flushed for each new value write. There is also no scheduling mechanism, so writes are synchronized with notifications, i.e. the stream blocks while the state is fully flushed out to disk, which might also slow down the sequence that is pushing the changes.

## Unresolved Questions

- Will we ever want to support state recovery for high-frequency state changes?
- Might there be alternative mechanisms whereby we could ensure that state persists on termination while minimizing file IO?