### PR TITLE
Add address prefix to pose tracking log name

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -5,7 +5,7 @@
     <Description>A package providing common acquisition and control functionality for all Project Aeon experiments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.5.0</VersionPrefix>
+    <VersionPrefix>0.5.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   

--- a/src/Aeon.Acquisition/LogPoseTracking.bonsai
+++ b/src/Aeon.Acquisition/LogPoseTracking.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.0"
+<WorkflowBuilder Version="2.8.1"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -12,14 +12,36 @@
         <Name>Source1</Name>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
-        <Property Name="Address" />
         <Property Name="IdentityIndex" />
+      </Expression>
+      <Expression xsi:type="ExternalizedMapping">
+        <Property Name="Address" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:FormatPose">
           <aeon:Address>255</aeon:Address>
           <aeon:IdentityIndex xsi:nil="true" />
         </Combinator>
+      </Expression>
+      <Expression xsi:type="GroupWorkflow">
+        <Name>Address</Name>
+        <Workflow>
+          <Nodes>
+            <Expression xsi:type="ExternalizedMapping">
+              <Property Name="Value" DisplayName="Address" />
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="IntProperty">
+                <Value>255</Value>
+              </Combinator>
+            </Expression>
+            <Expression xsi:type="WorkflowOutput" />
+          </Nodes>
+          <Edges>
+            <Edge From="0" To="1" Label="Source1" />
+            <Edge From="1" To="2" Label="Source1" />
+          </Edges>
+        </Workflow>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Value" DisplayName="LogName" />
@@ -43,8 +65,8 @@
         </Combinator>
       </Expression>
       <Expression xsi:type="Format">
-        <Format>{0}_{1}</Format>
-        <Selector>Item1,Item2.LogName</Selector>
+        <Format>{0}_{1}_{2}</Format>
+        <Selector>Item2,Item1,Item3.LogName</Selector>
       </Expression>
       <Expression xsi:type="PropertyMapping">
         <PropertyMappings>
@@ -59,18 +81,21 @@
       <Expression xsi:type="WorkflowOutput" />
     </Nodes>
     <Edges>
-      <Edge From="0" To="2" Label="Source1" />
-      <Edge From="1" To="2" Label="Source2" />
-      <Edge From="2" To="11" Label="Source1" />
-      <Edge From="3" To="4" Label="Source1" />
-      <Edge From="4" To="7" Label="Source1" />
+      <Edge From="0" To="3" Label="Source1" />
+      <Edge From="1" To="3" Label="Source2" />
+      <Edge From="2" To="3" Label="Source3" />
+      <Edge From="2" To="4" Label="Source1" />
+      <Edge From="3" To="13" Label="Source1" />
+      <Edge From="4" To="9" Label="Source1" />
       <Edge From="5" To="6" Label="Source1" />
-      <Edge From="6" To="7" Label="Source2" />
+      <Edge From="6" To="9" Label="Source2" />
       <Edge From="7" To="8" Label="Source1" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source3" />
       <Edge From="9" To="10" Label="Source1" />
-      <Edge From="10" To="11" Label="Source2" />
+      <Edge From="10" To="11" Label="Source1" />
       <Edge From="11" To="12" Label="Source1" />
+      <Edge From="12" To="13" Label="Source2" />
+      <Edge From="13" To="14" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
To accommodate the custom path suffix containing model path metadata the current implementation of this operator used `LogHarp` instead of `LogHarpDemux`. This was to avoid placing the message address at the end of a long variable length string.

However, the message address should still be included in the path. This PR adds the address as an intermediate path component, placed immediately after the `LogName` component. 

Fixes https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/533