### PR TITLE
Ensure sampling function starts on valid threshold

### DIFF
--- a/src/Aeon.Foraging/Aeon.Foraging.csproj
+++ b/src/Aeon.Foraging/Aeon.Foraging.csproj
@@ -6,7 +6,7 @@
     <Description>Provides acquisition and control modules for Project Aeon foraging experiments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Foraging</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   

--- a/src/Aeon.Foraging/RandomDepletion.bonsai
+++ b/src/Aeon.Foraging/RandomDepletion.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.0"
+<WorkflowBuilder Version="2.8.2"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:aeon="clr-namespace:Aeon.Acquisition;assembly=Aeon.Acquisition"
                  xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -123,6 +123,15 @@
             </Expression>
             <Expression xsi:type="ExternalizedMapping">
               <Property Name="Name" DisplayName="PatchState" />
+            </Expression>
+            <Expression xsi:type="SubscribeSubject">
+              <Name>PatchState</Name>
+            </Expression>
+            <Expression xsi:type="scr:ExpressionCondition">
+              <scr:Expression>!double.IsNaN(Item1)</scr:Expression>
+            </Expression>
+            <Expression xsi:type="Combinator">
+              <Combinator xsi:type="rx:SubscribeWhen" />
             </Expression>
             <Expression xsi:type="SubscribeSubject">
               <Name>PatchState</Name>
@@ -377,44 +386,48 @@ Item1.Item2 as Rate)</scr:Expression>
             <Edge From="1" To="2" Label="Source1" />
             <Edge From="2" To="4" Label="Source1" />
             <Edge From="3" To="4" Label="Source2" />
-            <Edge From="3" To="14" Label="Source1" />
-            <Edge From="3" To="18" Label="Source2" />
+            <Edge From="3" To="17" Label="Source1" />
+            <Edge From="3" To="21" Label="Source2" />
             <Edge From="5" To="9" Label="Source1" />
             <Edge From="6" To="7" Label="Source1" />
-            <Edge From="6" To="12" Label="Source2" />
-            <Edge From="6" To="21" Label="Source1" />
-            <Edge From="6" To="27" Label="Source1" />
-            <Edge From="6" To="33" Label="Source1" />
-            <Edge From="6" To="37" Label="Source2" />
+            <Edge From="6" To="10" Label="Source1" />
+            <Edge From="6" To="15" Label="Source2" />
+            <Edge From="6" To="24" Label="Source1" />
+            <Edge From="6" To="30" Label="Source1" />
+            <Edge From="6" To="36" Label="Source1" />
+            <Edge From="6" To="40" Label="Source2" />
             <Edge From="7" To="8" Label="Source1" />
             <Edge From="8" To="9" Label="Source2" />
-            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="9" To="12" Label="Source1" />
             <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="12" Label="Source1" />
+            <Edge From="11" To="12" Label="Source2" />
             <Edge From="12" To="13" Label="Source1" />
-            <Edge From="13" To="15" Label="Source1" />
-            <Edge From="14" To="15" Label="Source2" />
+            <Edge From="13" To="14" Label="Source1" />
+            <Edge From="14" To="15" Label="Source1" />
             <Edge From="15" To="16" Label="Source1" />
-            <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="18" Label="Source1" />
+            <Edge From="16" To="18" Label="Source1" />
+            <Edge From="17" To="18" Label="Source2" />
             <Edge From="18" To="19" Label="Source1" />
-            <Edge From="20" To="25" Label="Source1" />
+            <Edge From="19" To="20" Label="Source1" />
+            <Edge From="20" To="21" Label="Source1" />
             <Edge From="21" To="22" Label="Source1" />
-            <Edge From="22" To="23" Label="Source1" />
-            <Edge From="23" To="24" Label="Source1" />
-            <Edge From="24" To="25" Label="Source2" />
-            <Edge From="25" To="32" Label="Source1" />
-            <Edge From="26" To="31" Label="Source1" />
-            <Edge From="27" To="28" Label="Source1" />
-            <Edge From="28" To="29" Label="Source1" />
-            <Edge From="29" To="30" Label="Source1" />
-            <Edge From="30" To="31" Label="Source2" />
-            <Edge From="31" To="32" Label="Source2" />
-            <Edge From="32" To="34" Label="Source1" />
+            <Edge From="23" To="28" Label="Source1" />
+            <Edge From="24" To="25" Label="Source1" />
+            <Edge From="25" To="26" Label="Source1" />
+            <Edge From="26" To="27" Label="Source1" />
+            <Edge From="27" To="28" Label="Source2" />
+            <Edge From="28" To="35" Label="Source1" />
+            <Edge From="29" To="34" Label="Source1" />
+            <Edge From="30" To="31" Label="Source1" />
+            <Edge From="31" To="32" Label="Source1" />
+            <Edge From="32" To="33" Label="Source1" />
             <Edge From="33" To="34" Label="Source2" />
-            <Edge From="34" To="35" Label="Source1" />
-            <Edge From="35" To="36" Label="Source1" />
-            <Edge From="36" To="37" Label="Source1" />
+            <Edge From="34" To="35" Label="Source2" />
+            <Edge From="35" To="37" Label="Source1" />
+            <Edge From="36" To="37" Label="Source2" />
+            <Edge From="37" To="38" Label="Source1" />
+            <Edge From="38" To="39" Label="Source1" />
+            <Edge From="39" To="40" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
Functionality to interrupt the patch sampling function on a `NaN` threshold was added to allow aborting ongoing patch logic. However, if the invalid thresholds are not immediately replaced by valid values, the patch logic will continue to abort and resume in quick succession until a valid value is assigned.

This PR avoids this rapid loop of completion and re-subscription by waiting to subscribe to the movement stream until a valid threshold is provided, i.e. `NaN` can only be used to abort an ongoing valid foraging run.

Fixes https://github.com/SainsburyWellcomeCentre/aeon_experiments/issues/497