### PR TITLE
Add logging of all pose identity scores

### DIFF
--- a/src/Aeon.Acquisition/Aeon.Acquisition.csproj
+++ b/src/Aeon.Acquisition/Aeon.Acquisition.csproj
@@ -5,7 +5,7 @@
     <Description>A package providing common acquisition and control functionality for all Project Aeon experiments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Acquisition</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.5.1</VersionPrefix>
+    <VersionPrefix>0.6.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   
@@ -24,7 +24,7 @@
     <PackageReference Include="Harp.TimestampGeneratorGen3" Version="0.1.0" />
     <PackageReference Include="Bonsai.Osc" Version="2.7.0" />
     <PackageReference Include="Bonsai.Pylon" Version="0.3.0" />
-    <PackageReference Include="Bonsai.Sleap" Version="0.2.0" />
+    <PackageReference Include="Bonsai.Sleap" Version="0.3.0" />
     <PackageReference Include="Bonsai.Spinnaker" Version="0.7.1" />
     <PackageReference Include="Bonsai.System" Version="2.8.0" />
     <PackageReference Include="Bonsai.Scripting.Expressions" Version="2.8.0" />

--- a/src/Aeon.Acquisition/FormatPose.cs
+++ b/src/Aeon.Acquisition/FormatPose.cs
@@ -26,9 +26,13 @@ namespace Aeon.Acquisition
                 var i = 0;
                 var pose = payload.Value;
                 var timestamp = payload.Seconds;
-                var data = new float[5 + pose.Count * 3];
+                var data = new float[4 + pose.IdentityScores.Length + pose.Count * 3];
                 data[i++] = IdentityIndex.GetValueOrDefault(pose.IdentityIndex);
-                data[i++] = pose.Confidence;
+                for (int k = 0; k < pose.IdentityScores.Length; k++)
+                {
+                    data[i++] = pose.IdentityScores[k];
+                }
+
                 data[i++] = pose.Centroid.Position.X;
                 data[i++] = pose.Centroid.Position.Y;
                 data[i++] = pose.Centroid.Confidence;
@@ -51,11 +55,15 @@ namespace Aeon.Acquisition
                 return poseCollection.Select((pose, index) =>
                 {
                     int i = 0;
-                    var data = new float[5 + pose.Count * 3];
+                    var data = new float[4 + pose.IdentityScores.Length + pose.Count * 3];
                     data[i++] = IdentityIndex.HasValue
                         ? IdentityIndex.GetValueOrDefault() + index
                         : pose.IdentityIndex;
-                    data[i++] = pose.Confidence;
+                    for (int k = 0; k < pose.IdentityScores.Length; k++)
+                    {
+                        data[i++] = pose.IdentityScores[k];
+                    }
+
                     data[i++] = pose.Centroid.Position.X;
                     data[i++] = pose.Centroid.Position.Y;
                     data[i++] = pose.Centroid.Confidence;


### PR DESCRIPTION
To allow for downstream processing and matching of pose identities, this PR extends the `FormatPose` operator to write out all identity scores for each tracked instance. Furthermore it updates the SLEAP package to v0.3.0, allowing for the use of `FindPoseIdentityMatching` to do greedy assignment of poses to classes both for online processing and logging.