### PR TITLE
Avoid race conditions on patch replenishment

### DIFF
--- a/src/Aeon.Foraging/Aeon.Foraging.csproj
+++ b/src/Aeon.Foraging/Aeon.Foraging.csproj
@@ -6,7 +6,7 @@
     <Description>Provides acquisition and control modules for Project Aeon foraging experiments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Foraging</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.1.2</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   

--- a/src/Aeon.Foraging/RandomDepletion.bonsai
+++ b/src/Aeon.Foraging/RandomDepletion.bonsai
@@ -127,23 +127,6 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>PatchState</Name>
             </Expression>
-            <Expression xsi:type="scr:ExpressionTransform">
-              <scr:Expression>
-                new(
-                Item1 as Threshold,
-                Item2 as D0,
-                Item3 as Rate)
-              </scr:Expression>
-            </Expression>
-            <Expression xsi:type="scr:ExpressionCondition">
-              <scr:Expression>!double.IsNaN(Threshold) || Rate &gt; 0</scr:Expression>
-            </Expression>
-            <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:SubscribeWhen" />
-            </Expression>
-            <Expression xsi:type="SubscribeSubject">
-              <Name>PatchState</Name>
-            </Expression>
             <Expression xsi:type="MemberSelector">
               <Selector>Item1</Selector>
             </Expression>
@@ -400,49 +383,44 @@
             <Edge From="1" To="2" Label="Source1" />
             <Edge From="2" To="4" Label="Source1" />
             <Edge From="3" To="4" Label="Source2" />
-            <Edge From="3" To="18" Label="Source1" />
-            <Edge From="3" To="22" Label="Source2" />
-            <Edge From="5" To="10" Label="Source1" />
+            <Edge From="3" To="14" Label="Source1" />
+            <Edge From="3" To="18" Label="Source2" />
+            <Edge From="5" To="9" Label="Source1" />
             <Edge From="6" To="7" Label="Source1" />
-            <Edge From="6" To="11" Label="Source1" />
-            <Edge From="6" To="16" Label="Source2" />
-            <Edge From="6" To="25" Label="Source1" />
-            <Edge From="6" To="31" Label="Source1" />
-            <Edge From="6" To="37" Label="Source1" />
-            <Edge From="6" To="41" Label="Source2" />
+            <Edge From="6" To="12" Label="Source2" />
+            <Edge From="6" To="21" Label="Source1" />
+            <Edge From="6" To="27" Label="Source1" />
+            <Edge From="6" To="33" Label="Source1" />
+            <Edge From="6" To="37" Label="Source2" />
             <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="9" Label="Source1" />
-            <Edge From="9" To="10" Label="Source2" />
-            <Edge From="10" To="13" Label="Source1" />
+            <Edge From="8" To="9" Label="Source2" />
+            <Edge From="9" To="10" Label="Source1" />
+            <Edge From="10" To="11" Label="Source1" />
             <Edge From="11" To="12" Label="Source1" />
-            <Edge From="12" To="13" Label="Source2" />
-            <Edge From="13" To="14" Label="Source1" />
-            <Edge From="14" To="15" Label="Source1" />
+            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="13" To="15" Label="Source1" />
+            <Edge From="14" To="15" Label="Source2" />
             <Edge From="15" To="16" Label="Source1" />
             <Edge From="16" To="17" Label="Source1" />
-            <Edge From="17" To="19" Label="Source1" />
-            <Edge From="18" To="19" Label="Source2" />
-            <Edge From="19" To="20" Label="Source1" />
-            <Edge From="20" To="21" Label="Source1" />
+            <Edge From="17" To="18" Label="Source1" />
+            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="20" To="25" Label="Source1" />
             <Edge From="21" To="22" Label="Source1" />
             <Edge From="22" To="23" Label="Source1" />
-            <Edge From="24" To="29" Label="Source1" />
-            <Edge From="25" To="26" Label="Source1" />
-            <Edge From="26" To="27" Label="Source1" />
+            <Edge From="23" To="24" Label="Source1" />
+            <Edge From="24" To="25" Label="Source2" />
+            <Edge From="25" To="32" Label="Source1" />
+            <Edge From="26" To="31" Label="Source1" />
             <Edge From="27" To="28" Label="Source1" />
-            <Edge From="28" To="29" Label="Source2" />
-            <Edge From="29" To="36" Label="Source1" />
-            <Edge From="30" To="35" Label="Source1" />
-            <Edge From="31" To="32" Label="Source1" />
-            <Edge From="32" To="33" Label="Source1" />
-            <Edge From="33" To="34" Label="Source1" />
-            <Edge From="34" To="35" Label="Source2" />
-            <Edge From="35" To="36" Label="Source2" />
-            <Edge From="36" To="38" Label="Source1" />
-            <Edge From="37" To="38" Label="Source2" />
-            <Edge From="38" To="39" Label="Source1" />
-            <Edge From="39" To="40" Label="Source1" />
-            <Edge From="40" To="41" Label="Source1" />
+            <Edge From="28" To="29" Label="Source1" />
+            <Edge From="29" To="30" Label="Source1" />
+            <Edge From="30" To="31" Label="Source2" />
+            <Edge From="31" To="32" Label="Source2" />
+            <Edge From="32" To="34" Label="Source1" />
+            <Edge From="33" To="34" Label="Source2" />
+            <Edge From="34" To="35" Label="Source1" />
+            <Edge From="35" To="36" Label="Source1" />
+            <Edge From="36" To="37" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Aeon.Foraging/RandomDepletion.bonsai
+++ b/src/Aeon.Foraging/RandomDepletion.bonsai
@@ -127,8 +127,16 @@
             <Expression xsi:type="SubscribeSubject">
               <Name>PatchState</Name>
             </Expression>
+            <Expression xsi:type="scr:ExpressionTransform">
+              <scr:Expression>
+                new(
+                Item1 as Threshold,
+                Item2 as D0,
+                Item3 as Rate)
+              </scr:Expression>
+            </Expression>
             <Expression xsi:type="scr:ExpressionCondition">
-              <scr:Expression>!double.IsNaN(Item1)</scr:Expression>
+              <scr:Expression>!double.IsNaN(Threshold) || Rate &gt; 0</scr:Expression>
             </Expression>
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="rx:SubscribeWhen" />
@@ -140,7 +148,7 @@
               <Selector>Item1</Selector>
             </Expression>
             <Expression xsi:type="Combinator">
-              <Combinator xsi:type="rx:WithLatestFrom" />
+              <Combinator xsi:type="rx:CombineLatest" />
             </Expression>
             <Expression xsi:type="scr:ExpressionCondition">
               <scr:Expression>double.IsNaN(Item2) || Item1 &gt; Item2</scr:Expression>
@@ -189,10 +197,12 @@
                     </Combinator>
                   </Expression>
                   <Expression xsi:type="scr:ExpressionTransform">
-                    <scr:Expression>new(
-Item1.Item2 as D0,
-Item1.Item3 as Rate,
-Item2 as Random)</scr:Expression>
+                    <scr:Expression>
+                      new(
+                      Item1.Item2 as D0,
+                      Item1.Item3 as Rate,
+                      Item2 as Random)
+                    </scr:Expression>
                   </Expression>
                   <Expression xsi:type="InputMapping">
                     <PropertyMappings>
@@ -209,10 +219,12 @@ Item2 as Random)</scr:Expression>
                     <Combinator xsi:type="rx:Zip" />
                   </Expression>
                   <Expression xsi:type="scr:ExpressionTransform">
-                    <scr:Expression>new(
-Item2.Sample() + Item1.D0 as Threshold,
-Item1.D0 as D0,
-Item1.Rate as Rate)</scr:Expression>
+                    <scr:Expression>
+                      new(
+                      Item2.Sample() + Item1.D0 as Threshold,
+                      Item1.D0 as D0,
+                      Item1.Rate as Rate)
+                    </scr:Expression>
                   </Expression>
                   <Expression xsi:type="MemberSelector">
                     <Selector>Threshold,D0,Rate</Selector>
@@ -368,10 +380,12 @@ Item1.Rate as Rate)</scr:Expression>
               <Combinator xsi:type="rx:WithLatestFrom" />
             </Expression>
             <Expression xsi:type="scr:ExpressionTransform">
-              <scr:Expression>new(
-Item2.Item1 as Threshold,
-Item1.Item1 as D0,
-Item1.Item2 as Rate)</scr:Expression>
+              <scr:Expression>
+                new(
+                Item2.Item1 as Threshold,
+                Item1.Item1 as D0,
+                Item1.Item2 as Rate)
+              </scr:Expression>
             </Expression>
             <Expression xsi:type="MemberSelector">
               <Selector>Threshold,D0,Rate</Selector>
@@ -386,48 +400,49 @@ Item1.Item2 as Rate)</scr:Expression>
             <Edge From="1" To="2" Label="Source1" />
             <Edge From="2" To="4" Label="Source1" />
             <Edge From="3" To="4" Label="Source2" />
-            <Edge From="3" To="17" Label="Source1" />
-            <Edge From="3" To="21" Label="Source2" />
-            <Edge From="5" To="9" Label="Source1" />
+            <Edge From="3" To="18" Label="Source1" />
+            <Edge From="3" To="22" Label="Source2" />
+            <Edge From="5" To="10" Label="Source1" />
             <Edge From="6" To="7" Label="Source1" />
-            <Edge From="6" To="10" Label="Source1" />
-            <Edge From="6" To="15" Label="Source2" />
-            <Edge From="6" To="24" Label="Source1" />
-            <Edge From="6" To="30" Label="Source1" />
-            <Edge From="6" To="36" Label="Source1" />
-            <Edge From="6" To="40" Label="Source2" />
+            <Edge From="6" To="11" Label="Source1" />
+            <Edge From="6" To="16" Label="Source2" />
+            <Edge From="6" To="25" Label="Source1" />
+            <Edge From="6" To="31" Label="Source1" />
+            <Edge From="6" To="37" Label="Source1" />
+            <Edge From="6" To="41" Label="Source2" />
             <Edge From="7" To="8" Label="Source1" />
-            <Edge From="8" To="9" Label="Source2" />
-            <Edge From="9" To="12" Label="Source1" />
-            <Edge From="10" To="11" Label="Source1" />
-            <Edge From="11" To="12" Label="Source2" />
-            <Edge From="12" To="13" Label="Source1" />
+            <Edge From="8" To="9" Label="Source1" />
+            <Edge From="9" To="10" Label="Source2" />
+            <Edge From="10" To="13" Label="Source1" />
+            <Edge From="11" To="12" Label="Source1" />
+            <Edge From="12" To="13" Label="Source2" />
             <Edge From="13" To="14" Label="Source1" />
             <Edge From="14" To="15" Label="Source1" />
             <Edge From="15" To="16" Label="Source1" />
-            <Edge From="16" To="18" Label="Source1" />
-            <Edge From="17" To="18" Label="Source2" />
-            <Edge From="18" To="19" Label="Source1" />
+            <Edge From="16" To="17" Label="Source1" />
+            <Edge From="17" To="19" Label="Source1" />
+            <Edge From="18" To="19" Label="Source2" />
             <Edge From="19" To="20" Label="Source1" />
             <Edge From="20" To="21" Label="Source1" />
             <Edge From="21" To="22" Label="Source1" />
-            <Edge From="23" To="28" Label="Source1" />
-            <Edge From="24" To="25" Label="Source1" />
+            <Edge From="22" To="23" Label="Source1" />
+            <Edge From="24" To="29" Label="Source1" />
             <Edge From="25" To="26" Label="Source1" />
             <Edge From="26" To="27" Label="Source1" />
-            <Edge From="27" To="28" Label="Source2" />
-            <Edge From="28" To="35" Label="Source1" />
-            <Edge From="29" To="34" Label="Source1" />
-            <Edge From="30" To="31" Label="Source1" />
+            <Edge From="27" To="28" Label="Source1" />
+            <Edge From="28" To="29" Label="Source2" />
+            <Edge From="29" To="36" Label="Source1" />
+            <Edge From="30" To="35" Label="Source1" />
             <Edge From="31" To="32" Label="Source1" />
             <Edge From="32" To="33" Label="Source1" />
-            <Edge From="33" To="34" Label="Source2" />
+            <Edge From="33" To="34" Label="Source1" />
             <Edge From="34" To="35" Label="Source2" />
-            <Edge From="35" To="37" Label="Source1" />
-            <Edge From="36" To="37" Label="Source2" />
-            <Edge From="37" To="38" Label="Source1" />
+            <Edge From="35" To="36" Label="Source2" />
+            <Edge From="36" To="38" Label="Source1" />
+            <Edge From="37" To="38" Label="Source2" />
             <Edge From="38" To="39" Label="Source1" />
             <Edge From="39" To="40" Label="Source1" />
+            <Edge From="40" To="41" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>


### PR DESCRIPTION
This PR resolves two critical edge cases with patch replenishment:
1. Threshold crossing was using `WithLatestFrom` to get the current patch threshold. This means patch threshold transitions had to wait for a sample arriving from the wheel. This created a race between the block transition and local patch transition notifications. Changing the operator to `CombineLatest` ensures patch transition to NaN is synchronized and strictly preceding block transition.
2. If NaN threshold values end up in state recovery, it was impossible to resume patch operation since the sequence would never subscribe, and therefore could not be terminated to sample a new threshold. With the new synchronized patch transition behavior, this guard became unnecessary, and was removed.