### PR TITLE
Pack and upload artifacts for release builds

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -11,6 +11,9 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   ContinuousIntegrationBuild: true
+  CiRunNumber: ${{ github.run_number }}
+  CiRunMainSuffix: ci${{ github.run_number }}
+  CiRunPullSuffix: pull-${{ github.event.number }}-ci${{ github.run_number }}
 jobs:
   audit:
     strategy:
@@ -21,6 +24,9 @@ jobs:
         include:
           - os: ubuntu-latest
             test-filter: --filter TestCategory!=DriverDependent
+          - os: windows-latest
+            configuration: release
+            collect-packages: true
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -37,8 +43,20 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration ${{ matrix.configuration }}
 
-    - name: Pack
-      run: dotnet pack --no-build --configuration ${{ matrix.configuration }}
-
     - name: Test
       run: dotnet test --no-build --configuration ${{ matrix.configuration }} ${{ matrix.test-filter }}
+
+    - name: Pack
+      id: pack
+      if: matrix.collect-packages
+      env:
+        CiBuildVersionSuffix: ${{ github.ref_name == 'main' && env.CiRunMainSuffix || env.CiRunPullSuffix }}
+      run: dotnet pack --no-build --configuration ${{ matrix.configuration }}
+
+    - name: Collect packages
+      uses: actions/upload-artifact@v4
+      if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
+      with:
+        name: Packages
+        if-no-files-found: error
+        path: artifacts/package/${{matrix.configuration}}/**

--- a/Aeon.sln
+++ b/Aeon.sln
@@ -20,11 +20,16 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aeon.Foraging", "src\Aeon.F
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aeon.Environment", "src\Aeon.Environment\Aeon.Environment.csproj", "{49FC1C61-791E-41CF-BB7C-C2AC26AFAFE3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aeon.Video", "src\Aeon.Video\Aeon.Video.csproj", "{1D11793E-85E9-473C-8EF6-F4BD4B249E30}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aeon.Video", "src\Aeon.Video\Aeon.Video.csproj", "{1D11793E-85E9-473C-8EF6-F4BD4B249E30}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aeon.Vision", "src\Aeon.Vision\Aeon.Vision.csproj", "{709D0302-5A4F-4F76-8596-41B74DF3B3E9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aeon.Vision", "src\Aeon.Vision\Aeon.Vision.csproj", "{709D0302-5A4F-4F76-8596-41B74DF3B3E9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aeon.Vision.Sleap", "src\Aeon.Vision.Sleap\Aeon.Vision.Sleap.csproj", "{0D9D431D-EA23-4610-B262-313A48BFE34B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aeon.Vision.Sleap", "src\Aeon.Vision.Sleap\Aeon.Vision.Sleap.csproj", "{0D9D431D-EA23-4610-B262-313A48BFE34B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{EE2D6E09-6996-49EC-9A7F-4569854BC613}"
+	ProjectSection(SolutionItems) = preProject
+		build\Version.props = build\Version.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -52,10 +57,6 @@ Global
 		{49FC1C61-791E-41CF-BB7C-C2AC26AFAFE3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{49FC1C61-791E-41CF-BB7C-C2AC26AFAFE3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{49FC1C61-791E-41CF-BB7C-C2AC26AFAFE3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0D9D431D-EA23-4610-B262-313A48BFE34B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0D9D431D-EA23-4610-B262-313A48BFE34B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0D9D431D-EA23-4610-B262-313A48BFE34B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0D9D431D-EA23-4610-B262-313A48BFE34B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{1D11793E-85E9-473C-8EF6-F4BD4B249E30}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1D11793E-85E9-473C-8EF6-F4BD4B249E30}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1D11793E-85E9-473C-8EF6-F4BD4B249E30}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -64,6 +65,10 @@ Global
 		{709D0302-5A4F-4F76-8596-41B74DF3B3E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{709D0302-5A4F-4F76-8596-41B74DF3B3E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{709D0302-5A4F-4F76-8596-41B74DF3B3E9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D9D431D-EA23-4610-B262-313A48BFE34B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D9D431D-EA23-4610-B262-313A48BFE34B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D9D431D-EA23-4610-B262-313A48BFE34B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D9D431D-EA23-4610-B262-313A48BFE34B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,10 +12,11 @@
     <IncludeSymbols>true</IncludeSymbols>
     <RepositoryType>git</RepositoryType>
     <VersionPrefix>0.7.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
     <LangVersion>9.0</LangVersion>
     <Features>strict</Features>
   </PropertyGroup>
+  
+  <Import Project="build/Version.props" />
 
   <ItemGroup>
     <Content Include="..\..\LICENSE" PackagePath="/" />

--- a/build/Version.props
+++ b/build/Version.props
@@ -1,0 +1,20 @@
+<Project>
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' != 'true'">
+    <!-- When making local builds DevVersion can be overridden to generate multiple local versions -->
+    <DevVersion Condition="'$(DevVersion)' == ''">0</DevVersion>
+
+    <VersionSuffix>dev$(DevVersion)</VersionSuffix>
+    <_FileVersionRevision>$([MSBuild]::Add(60000, $(DevVersion)))</_FileVersionRevision>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
+    <VersionSuffix>$(CiBuildVersionSuffix)</VersionSuffix>
+    <_FileVersionRevision>0</_FileVersionRevision>
+    <_FileVersionRevision Condition="'$(CiBuildVersionSuffix)' != '' and '$(CiRunNumber)' != ''">$(CiRunNumber)</_FileVersionRevision>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Force malformed versions to be an error -->
+    <WarningsAsErrors>$(WarningsAsErrors);CS7035</WarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/src/Aeon.Database/Aeon.Database.csproj
+++ b/src/Aeon.Database/Aeon.Database.csproj
@@ -5,7 +5,6 @@
     <Description>Provides querying and schema functionality for Project Aeon databases.</Description>
     <PackageTags>Bonsai Rx Project Aeon Database</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aeon.Environment/Aeon.Environment.csproj
+++ b/src/Aeon.Environment/Aeon.Environment.csproj
@@ -6,7 +6,6 @@
     <Description>Provides reactive modules for controlling and monitoring Project Aeon environments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Environment</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Foraging/Aeon.Foraging.csproj
+++ b/src/Aeon.Foraging/Aeon.Foraging.csproj
@@ -6,7 +6,6 @@
     <Description>Provides acquisition and control modules for Project Aeon foraging experiments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Foraging</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Aeon.Video/Aeon.Video.csproj
+++ b/src/Aeon.Video/Aeon.Video.csproj
@@ -6,7 +6,6 @@
     <Description>Provides reactive modules for video acquisition in Project Aeon experiments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Video</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Aeon.Vision.Sleap/Aeon.Vision.Sleap.csproj
+++ b/src/Aeon.Vision.Sleap/Aeon.Vision.Sleap.csproj
@@ -6,7 +6,6 @@
     <Description>Provides reactive modules for SLEAP based pose estimation used for Project Aeon experiments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Vision Sleap</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aeon.Vision/Aeon.Vision.csproj
+++ b/src/Aeon.Vision/Aeon.Vision.csproj
@@ -6,7 +6,6 @@
     <Description>Provides reactive modules for computer vision used for Project Aeon experiments.</Description>
     <PackageTags>Bonsai Rx Project Aeon Vision</PackageTags>
     <TargetFramework>net472</TargetFramework>
-    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As a first step in building a release automation workflow, this PR conditions the `Pack` step on the release output and collects the final generated NuGet packages as part of the action output.

Appropriate pre-release suffixes are automatically generated for both local and CI builds to prevent name clashes.