### PR TITLE
Remove warnings from CI build

### DIFF
--- a/src/Aeon.Acquisition/MetadataSource.cs
+++ b/src/Aeon.Acquisition/MetadataSource.cs
@@ -20,7 +20,7 @@ namespace Aeon.Acquisition
 
         public virtual IObservable<TMetadata> Process()
         {
-            return subject.ObserveOn(Scheduler.TaskPool);
+            return subject.ObserveOn(TaskPoolScheduler.Default);
         }
 
         public virtual IObservable<Timestamped<TMetadata>> Process(IObservable<HarpMessage> source)

--- a/src/Aeon.Video/Aeon.Video.csproj
+++ b/src/Aeon.Video/Aeon.Video.csproj
@@ -9,6 +9,11 @@
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!-- The pylon and spinnaker packages include custom build scripts to deploy multi-architecture dependencies -->
+    <NoWarn>$(NoWarn);MSB3270</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <EmbeddedResource Include="**\*.bonsai" />
   </ItemGroup>


### PR DESCRIPTION
This PR addresses build issues resulting from processor architecture mismatches and a single obsolete property access. The processor architecture warning was disabled as both Pylon and Spinnaker reference packages include automatic build scripts to deploy for x86 and x64 processor architectures.

With these changes the CI builds should now run without warnings.