### PR TITLE
Publish packages to github on push to main

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  workflow_dispatch:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -29,34 +28,58 @@ jobs:
             collect-packages: true
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.x
-     
-    - name: Restore
-      run: dotnet restore
- 
-    - name: Build
-      run: dotnet build --no-restore --configuration ${{ matrix.configuration }}
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+      
+      - name: Restore
+        run: dotnet restore
+  
+      - name: Build
+        run: dotnet build --no-restore --configuration ${{ matrix.configuration }}
 
-    - name: Test
-      run: dotnet test --no-build --configuration ${{ matrix.configuration }} ${{ matrix.test-filter }}
+      - name: Test
+        run: dotnet test --no-build --configuration ${{ matrix.configuration }} ${{ matrix.test-filter }}
 
-    - name: Pack
-      id: pack
-      if: matrix.collect-packages
-      env:
-        CiBuildVersionSuffix: ${{ github.ref_name == 'main' && env.CiRunMainSuffix || env.CiRunPullSuffix }}
-      run: dotnet pack --no-build --configuration ${{ matrix.configuration }}
+      - name: Pack
+        id: pack
+        if: matrix.collect-packages
+        env:
+          CiBuildVersionSuffix: ${{ github.ref_name == 'main' && env.CiRunMainSuffix || env.CiRunPullSuffix }}
+        run: dotnet pack --no-build --configuration ${{ matrix.configuration }}
 
-    - name: Collect packages
-      uses: actions/upload-artifact@v4
-      if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
-      with:
-        name: Packages
-        if-no-files-found: error
-        path: artifacts/package/${{matrix.configuration}}/**
+      - name: Collect packages
+        uses: actions/upload-artifact@v4
+        if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
+        with:
+          name: Packages
+          if-no-files-found: error
+          path: artifacts/package/${{matrix.configuration}}/**
+
+  publish-github:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    needs: [audit]
+    if: github.event_name == 'push'
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
+
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: Packages
+
+      - name: Push to GitHub Packages
+        run: dotnet nuget push "Packages/*.nupkg" --skip-duplicate --no-symbols --api-key ${{secrets.GITHUB_TOKEN}} --source https://nuget.pkg.github.com/${{github.repository_owner}}
+        env:
+          # This is a workaround for https://github.com/NuGet/Home/issues/9775
+          DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER: 0

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -11,7 +11,7 @@ env:
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
   ContinuousIntegrationBuild: true
   CiRunNumber: ${{ github.run_number }}
-  CiRunMainSuffix: ci${{ github.run_number }}
+  CiRunPushSuffix: ${{ github.ref_name }}-ci${{ github.run_number }}
   CiRunPullSuffix: pull-${{ github.event.number }}-ci${{ github.run_number }}
 jobs:
   audit:
@@ -49,7 +49,7 @@ jobs:
         id: pack
         if: matrix.collect-packages
         env:
-          CiBuildVersionSuffix: ${{ github.ref_name == 'main' && env.CiRunMainSuffix || env.CiRunPullSuffix }}
+          CiBuildVersionSuffix: ${{ github.event_name == 'push' && env.CiRunPushSuffix || env.CiRunPullSuffix }}
         run: dotnet pack --no-build --configuration ${{ matrix.configuration }}
 
       - name: Collect packages


### PR DESCRIPTION
To facilitate the deployment of continuous integration builds for testing, and to avoid polluting the stable NuGet feed with too many packages, this PR automates packing and publishing of packages to the repository local GitHub package feed.

This feed requires authentication by default, but we can use it as a stepping stone for a full release automation workflow.