### PR TITLE
Synchronizer monitor mean timestamps only used when devices report heartbeats

### DIFF
--- a/src/Aeon.Acquisition/SynchronizerMonitor.bonsai
+++ b/src/Aeon.Acquisition/SynchronizerMonitor.bonsai
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<WorkflowBuilder Version="2.8.1"
+<WorkflowBuilder Version="2.8.2"
                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                  xmlns:rx="clr-namespace:Bonsai.Reactive;assembly=Bonsai.Core"
                  xmlns:harp="clr-namespace:Bonsai.Harp;assembly=Bonsai.Harp"
@@ -91,13 +91,20 @@
       <Expression xsi:type="MemberSelector">
         <Selector>Item2</Selector>
       </Expression>
+      <Expression xsi:type="harp:Parse">
+        <harp:Register xsi:type="harp:ParseMessagePayload">
+          <harp:PayloadType>Timestamp</harp:PayloadType>
+          <harp:IsArray>false</harp:IsArray>
+        </harp:Register>
+      </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Zip" />
       </Expression>
       <Expression xsi:type="scr:ExpressionTransform">
         <scr:Expression>new(
 Item1 as Stats,
-Item2 as Names)</scr:Expression>
+Item2 as Names,
+Item3 as SyncTimestamp)</scr:Expression>
       </Expression>
       <Expression xsi:type="SubscribeSubject">
         <Name>HeartbeatSources</Name>
@@ -111,7 +118,7 @@ Item2 as Names)</scr:Expression>
       <Expression xsi:type="scr:ExpressionTransform">
         <scr:Expression>new(
 Item1.Stats.Mean as MeanTimestamp,
-DateTime(1904, 1, 1) + TimeSpan.FromSeconds(Item1.Stats.Mean) as MeanUtcTimestamp,
+DateTime(1904, 1, 1) + TimeSpan.FromSeconds(Double.IsNan(Item1.Stats.Mean) ? Item1.SyncTimestamp : Item1.Stats.Mean) as MeanUtcTimestamp,
 Item2 as ExpectedDeviceCount,
 Item1.Stats.Count as DeviceCount,
 Item1.Stats.Maximum - Item1.Stats.Minimum as MaxDifference,
@@ -128,18 +135,20 @@ string.Join("\t", Item1.Names) as Elements)</scr:Expression>
       <Edge From="5" To="8" Label="Source1" />
       <Edge From="6" To="7" Label="Source1" />
       <Edge From="7" To="8" Label="Source2" />
+      <Edge From="7" To="13" Label="Source1" />
       <Edge From="8" To="9" Label="Source1" />
       <Edge From="9" To="10" Label="Source1" />
       <Edge From="9" To="12" Label="Source1" />
       <Edge From="10" To="11" Label="Source1" />
-      <Edge From="11" To="13" Label="Source1" />
-      <Edge From="12" To="13" Label="Source2" />
-      <Edge From="13" To="14" Label="Source1" />
-      <Edge From="14" To="17" Label="Source1" />
-      <Edge From="15" To="16" Label="Source1" />
-      <Edge From="16" To="17" Label="Source2" />
-      <Edge From="17" To="18" Label="Source1" />
+      <Edge From="11" To="14" Label="Source1" />
+      <Edge From="12" To="14" Label="Source2" />
+      <Edge From="13" To="14" Label="Source3" />
+      <Edge From="14" To="15" Label="Source1" />
+      <Edge From="15" To="18" Label="Source1" />
+      <Edge From="16" To="17" Label="Source1" />
+      <Edge From="17" To="18" Label="Source2" />
       <Edge From="18" To="19" Label="Source1" />
+      <Edge From="19" To="20" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>


### PR DESCRIPTION
When no devices report a heartbeat, DescriptiveStatistics yields a NaN. In this scenario the mean timestamp considered is taken from the synchronizer heartbeat that triggered the BufferTrigger.

Fixes #172 