### PR TITLE
Add Mono installation step for Ubuntu in CI audit workflow

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -28,6 +28,18 @@ jobs:
             collect-packages: true
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Mono (Ubuntu only)
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          sudo apt install -y ca-certificates gnupg
+          sudo gpg --homedir /tmp --no-default-keyring \
+            --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg \
+            --keyserver hkp://keyserver.ubuntu.com:80 \
+            --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+          echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+          sudo apt update
+          sudo apt install -y mono-complete
+
       - name: Checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -43,12 +43,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Test Dotnet
-        run: |
-          dotnet --version
-          dotnet --info
-          dotnet --list-runtimes
-          dotnet --list-sdks
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
       
       - name: Restore
         run: dotnet restore
@@ -81,12 +79,10 @@ jobs:
     needs: [audit]
     if: github.event_name == 'push'
     steps:
-      - name: Test Dotnet
-        run: |
-          dotnet --version
-          dotnet --info
-          dotnet --list-runtimes
-          dotnet --list-sdks
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.x
 
       - name: Download packages
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -43,10 +43,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.x
+      - name: Test Dotnet
+        run: |
+          dotnet --version
+          dotnet --info
+          dotnet --list-runtimes
+          dotnet --list-sdks
       
       - name: Restore
         run: dotnet restore
@@ -79,10 +81,12 @@ jobs:
     needs: [audit]
     if: github.event_name == 'push'
     steps:
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: 8.x
+      - name: Test Dotnet
+        run: |
+          dotnet --version
+          dotnet --info
+          dotnet --list-runtimes
+          dotnet --list-sdks
 
       - name: Download packages
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -9,6 +9,7 @@ env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_GENERATE_ASPNET_CERTIFICATE: false
+  DOTNET_INSTALL_DIR: "./.dotnet"
   ContinuousIntegrationBuild: true
   CiRunNumber: ${{ github.run_number }}
   CiRunPushSuffix: ${{ github.ref_name }}-ci${{ github.run_number }}


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/11675#issuecomment-2741071822

I've also had to configure `DOTNET_INSTALL_DIR` as a workaround to this [issue](https://github.com/actions/setup-dotnet/issues/565#issuecomment-2556316163).