### PR TITLE
Add operator for creating video data frame objects

### DIFF
--- a/src/Aeon.Video/CreateVideoDataFrame.cs
+++ b/src/Aeon.Video/CreateVideoDataFrame.cs
@@ -1,0 +1,19 @@
+﻿using Bonsai;
+using OpenCV.Net;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace Aeon.Video
+{
+    [Combinator]
+    [Description("Converts a sequence of image-metadata pairs into a sequence of VideoDataFrame objects.")]
+    public class CreateVideoDataFrame
+    {
+        public IObservable<VideoDataFrame> Process(IObservable<Tuple<IplImage, VideoChunkData>> source)
+        {
+            return source.Select(xs => new VideoDataFrame(xs.Item1, xs.Item2));
+        }
+    }
+}


### PR DESCRIPTION
Video logging operators require using `VideoDataFrame` objects to encode video metadata such as the frame counter and hardware timestamp. However, it is sometimes useful to process the raw image online prior to logging, which is hard to do while retaining the video metadata.

This operator makes it easier to recreate a video metadata object around a post-processed frame by using existing chunk data.

Closes #233 