### PR TITLE
Format epoch and chunk file names as ISO 8601

### DIFF
--- a/src/Aeon.Acquisition/FormatDate.cs
+++ b/src/Aeon.Acquisition/FormatDate.cs
@@ -1,4 +1,4 @@
-using Bonsai;
+﻿using Bonsai;
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 
 namespace Aeon.Acquisition
 {
+    [Obsolete]
     [Combinator]
     [Description("Formats a date time into a string with no illegal path characters.")]
     [WorkflowElementCategory(ElementCategory.Transform)]

--- a/src/Aeon.Acquisition/FormatDateTimeIso8601.cs
+++ b/src/Aeon.Acquisition/FormatDateTimeIso8601.cs
@@ -1,0 +1,24 @@
+﻿using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace Aeon.Acquisition
+{
+    [Combinator]
+    [Description("Formats a date time into an ISO 8601 string with no illegal path characters.")]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    public class FormatDateTimeIso8601
+    {
+        public IObservable<string> Process(IObservable<DateTime> source)
+        {
+            return source.Select(value => value.ToString("yyyy-MM-ddTHHmmss.FFFFFFFK").Replace(":", string.Empty));
+        }
+
+        public IObservable<string> Process(IObservable<DateTimeOffset> source)
+        {
+            return source.Select(value => value.ToString("yyyy-MM-ddTHHmmss.FFFFFFFzzz").Replace(":", string.Empty));
+        }
+    }
+}

--- a/src/Aeon.Acquisition/FormatFileName.bonsai
+++ b/src/Aeon.Acquisition/FormatFileName.bonsai
@@ -27,7 +27,7 @@
         <Name>Source1</Name>
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="aeon:FormatDate" />
+        <Combinator xsi:type="aeon:FormatDateTimeIso8601" />
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Value" DisplayName="Extension" Description="The file extension" />

--- a/src/Aeon.Acquisition/GroupByTime.cs
+++ b/src/Aeon.Acquisition/GroupByTime.cs
@@ -19,8 +19,8 @@ namespace Aeon.Acquisition
             ChunkSize = 1;
         }
 
-        // The default real-time reference is unix time in total seconds from 1904
-        internal static readonly DateTime ReferenceTime = new(1904, 1, 1);
+        // The default real-time reference is universal unix time in total seconds from 1904
+        internal static readonly DateTime ReferenceTime = new(1904, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         [Description("The size of each chunk, in whole hours.")]
         public int ChunkSize { get; set; }

--- a/src/Aeon.Acquisition/LogController.bonsai
+++ b/src/Aeon.Acquisition/LogController.bonsai
@@ -26,7 +26,10 @@
         <Selector>Timestamp.UtcDateTime</Selector>
       </Expression>
       <Expression xsi:type="Combinator">
-        <Combinator xsi:type="aeon:FormatDate" />
+        <Combinator xsi:type="aeon:TruncateDateTime" />
+      </Expression>
+      <Expression xsi:type="Combinator">
+        <Combinator xsi:type="aeon:FormatDateTimeIso8601" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Zip" />
@@ -64,15 +67,16 @@
       <Edge From="1" To="2" Label="Source1" />
       <Edge From="2" To="3" Label="Source1" />
       <Edge From="2" To="4" Label="Source1" />
-      <Edge From="3" To="6" Label="Source1" />
+      <Edge From="3" To="7" Label="Source1" />
       <Edge From="4" To="5" Label="Source1" />
-      <Edge From="5" To="6" Label="Source2" />
-      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="5" To="6" Label="Source1" />
+      <Edge From="6" To="7" Label="Source2" />
       <Edge From="7" To="8" Label="Source1" />
       <Edge From="8" To="9" Label="Source1" />
-      <Edge From="10" To="11" Label="Source1" />
+      <Edge From="9" To="10" Label="Source1" />
       <Edge From="11" To="12" Label="Source1" />
       <Edge From="12" To="13" Label="Source1" />
+      <Edge From="13" To="14" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/TruncateDateTime.cs
+++ b/src/Aeon.Acquisition/TruncateDateTime.cs
@@ -1,0 +1,24 @@
+﻿using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+
+namespace Aeon.Acquisition
+{
+    [Combinator]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Converts a sequence of date-time objects by truncating each value to whole seconds.")]
+    public class TruncateDateTime
+    {
+        public IObservable<DateTime> Process(IObservable<DateTime> source)
+        {
+            return source.Select(value => value.AddTicks(-(value.Ticks % TimeSpan.TicksPerSecond)));
+        }
+
+        public IObservable<DateTimeOffset> Process(IObservable<DateTimeOffset> source)
+        {
+            return source.Select(value => value.AddTicks(-(value.Ticks % TimeSpan.TicksPerSecond)));
+        }
+    }
+}


### PR DESCRIPTION
This PR enforces standard [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) date-time strings for epoch and chunk names. The main difference is removal of hyphens in the time component, and adding the explicit `Z` suffix to indicate UTC time is used.

Before:
```
data/2024-09-17T10-15-43/CameraTop/CameraTop_200_2024-09-17T10-00-00.bin
```

After:
```
data/2024-09-17T101543Z/CameraTop/CameraTop_200_2024-09-17T100000Z.bin
```

The benefits are interoperability, [`datetime.fromisoformat`](https://docs.python.org/3/library/datetime.html#datetime.date.fromisoformat) can be used to parse chunk names, and format becomes closer to NeuroBlueprint datetime fields (see https://github.com/neuroinformatics-unit/NeuroBlueprint/issues/31 and https://github.com/neuroinformatics-unit/NeuroBlueprint/pull/76).

Backwards compatibility on the `aeon_api` side can be enforced by having a fallback loading with the original (custom) format.

### Change set

[Add operator for date-time formatting into ISO8601](https://github.com/SainsburyWellcomeCentre/aeon_acquisition/commit/049afa5d5e1575fd395e3120842df19a9b49ca54) 

The format string is identical to the round-trip "o" format except that
the fractional part will be ommitted if it is equal to zero.

[Add operator for truncating date-time objects](https://github.com/SainsburyWellcomeCentre/aeon_acquisition/commit/1a140cd870ed034a5f7b373ab3f9c68c1c6e9043) 

This allows explicit truncation of fractional time information instead
of having it implicit inside the date formatting operator.

[Define harp reference time as UTC time](https://github.com/SainsburyWellcomeCentre/aeon_acquisition/commit/021b0947aa3f3a99c545090e9710140286adb3f4)

[Format epoch and chunk file names as ISO 8601](https://github.com/SainsburyWellcomeCentre/aeon_acquisition/commit/18243c897f71a77555f0709594b5d7d9f5265089) 

To allow more explicit and standard epoch and chunk date-time strings,
we adopt a full ISO 8601 specification, where hyphens are dropped on
the time component, and explicit UTC timezone is adopted.

[Deprecate legacy date formatting operator](https://github.com/SainsburyWellcomeCentre/aeon_acquisition/pull/242/commits/5364c7eacc72d3e370fd6af5f8d0ef5d9810e471)