### PR TITLE
Update CI action versions

### DIFF
--- a/.github/workflows/Aeon.Acquisition.yml
+++ b/.github/workflows/Aeon.Acquisition.yml
@@ -51,25 +51,23 @@ jobs:
             collect-packages: true
     name: ${{matrix.platform.name}} ${{matrix.configuration}}
     runs-on: ${{matrix.platform.os}}
-    outputs:
-      need-workflow-image-render: ${{steps.configure-build.outputs.need-workflow-image-render}}
     steps:
       # ----------------------------------------------------------------------- Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       # ----------------------------------------------------------------------- Set up tools
       - name: Set up .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Configure build
       - name: Configure build
         id: configure-build
-        uses: bonsai-rx/configure-build@v1
+        uses: bonsai-rx/configure-build@v2
 
       # ----------------------------------------------------------------------- Build
       - name: Restore
@@ -89,7 +87,7 @@ jobs:
 
       # ----------------------------------------------------------------------- Collect artifacts
       - name: Collect NuGet packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: matrix.collect-packages && steps.pack.outcome == 'success' && always()
         with:
           name: Packages
@@ -117,13 +115,13 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Set up .NET
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/
@@ -159,13 +157,13 @@ jobs:
     steps:
       # ----------------------------------------------------------------------- Set up .NET
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.x
 
       # ----------------------------------------------------------------------- Download built packages
       - name: Download built packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: Packages
           path: artifacts/packages/


### PR DESCRIPTION
Brings the CI workflow up to date for node24 and removes the leftover `need-workflow-image-render` build output that no job in this workflow consumes.