### PR TITLE
Complete GroupByTime chunks on source advance

### DIFF
--- a/src/Aeon.Acquisition/GroupByTime.cs
+++ b/src/Aeon.Acquisition/GroupByTime.cs
@@ -9,21 +9,6 @@ using System.Xml;
 
 namespace Aeon.Acquisition
 {
-    /// <summary>
-    /// Represents an operator that groups Harp time-series in whole hour chunks of fixed size.
-    /// </summary>
-    /// <remarks>
-    /// Each chunk group stays open until the sequence terminates unless <see cref="ClosingDuration"/>
-    /// is set. When it is set, a chunk closes once the clock advances past the end of the chunk plus
-    /// that duration, with a heartbeat source driving the clock when one is provided and the incoming
-    /// timestamps driving it otherwise. A grace of about two seconds suits the Harp synchronization
-    /// model, where sync pulses land on the whole-second boundary and a device may step backward around
-    /// a boundary but never beyond one sync period, so the grace keeps such a step from falling into an
-    /// already closed chunk. A larger backward jump, such as connecting a new synchronizer, exceeds the
-    /// grace and reopens the closed chunk as a new group. The chunk size and closing duration are read
-    /// once when the grouped sequence is created, so a property mapping applied while the sequence is
-    /// running does not resize open chunks.
-    /// </remarks>
     [Combinator]
     [Description("Groups Harp time-series in whole hour chunks of fixed size.")]
     [WorkflowElementCategory(ElementCategory.Combinator)]

--- a/src/Aeon.Acquisition/GroupByTime.cs
+++ b/src/Aeon.Acquisition/GroupByTime.cs
@@ -9,6 +9,21 @@ using System.Xml;
 
 namespace Aeon.Acquisition
 {
+    /// <summary>
+    /// Represents an operator that groups Harp time-series in whole hour chunks of fixed size.
+    /// </summary>
+    /// <remarks>
+    /// Each chunk group stays open until the sequence terminates unless <see cref="ClosingDuration"/>
+    /// is set. When it is set, a chunk closes once the clock advances past the end of the chunk plus
+    /// that duration, with a heartbeat source driving the clock when one is provided and the incoming
+    /// timestamps driving it otherwise. A grace of about two seconds suits the Harp synchronization
+    /// model, where sync pulses land on the whole-second boundary and a device may step backward around
+    /// a boundary but never beyond one sync period, so the grace keeps such a step from falling into an
+    /// already closed chunk. A larger backward jump, such as connecting a new synchronizer, exceeds the
+    /// grace and reopens the closed chunk as a new group. The chunk size and closing duration are read
+    /// once when the grouped sequence is created, so a property mapping applied while the sequence is
+    /// running does not resize open chunks.
+    /// </remarks>
     [Combinator]
     [Description("Groups Harp time-series in whole hour chunks of fixed size.")]
     [WorkflowElementCategory(ElementCategory.Combinator)]
@@ -30,13 +45,13 @@ namespace Aeon.Acquisition
         public TimeSpan? ClosingDuration { get; set; }
 
         [Browsable(false)]
-        [XmlElement(nameof(ClosingDuration))]
+        [XmlElement(nameof(ClosingDuration), IsNullable = true)]
         public string ClosingDurationXml
         {
             get
             {
                 var timeShift = ClosingDuration;
-                if (timeShift.HasValue) return XmlConvert.ToString(timeShift.Value);
+                if (timeShift.HasValue) return XmlConvert.ToString(timeShift.GetValueOrDefault());
                 else return null;
             }
             set
@@ -46,60 +61,64 @@ namespace Aeon.Acquisition
             }
         }
 
-        DateTime GetChunkIndex(double seconds)
+        static DateTime GetChunkIndex(double seconds, int chunkSize)
         {
             var currentTime = ReferenceTime.AddSeconds(seconds);
-            var timeBin = currentTime.Hour / ChunkSize;
-            return currentTime.Date.AddHours(timeBin * ChunkSize);
+            var timeBin = currentTime.Hour / chunkSize;
+            return currentTime.Date.AddHours(timeBin * chunkSize);
+        }
+
+        static bool ShouldCloseChunk(DateTime chunkKey, double seconds, int chunkSize, TimeSpan closingDuration)
+        {
+            var elementTimestamp = ReferenceTime.AddSeconds(seconds);
+            var elementDelta = elementTimestamp - chunkKey;
+            return elementDelta > new TimeSpan(chunkSize, 0, 0) + closingDuration;
+        }
+
+        IObservable<IGroupedObservable<DateTime, TResult>> Process<TSource, TResult>(
+            IObservable<TSource> source,
+            Func<TSource, double> timeSelector,
+            Func<TSource, TResult> resultSelector,
+            IObservable<HarpMessage> heartbeats)
+        {
+            var chunkSize = ChunkSize;
+            var closingDuration = ClosingDuration;
+
+            DateTime keySelector(TSource value) => GetChunkIndex(timeSelector(value), chunkSize);
+            if (!closingDuration.HasValue)
+                return source.GroupBy(keySelector, resultSelector);
+
+            IObservable<IGroupedObservable<DateTime, TResult>> GroupByUntilChunkCloses(IObservable<TSource> source, IObservable<double> clock)
+                => source.GroupByUntil(keySelector, resultSelector,
+                    chunk => clock.FirstOrDefaultAsync(seconds => ShouldCloseChunk(chunk.Key, seconds, chunkSize, closingDuration.GetValueOrDefault())));
+
+            return heartbeats != null
+                ? GroupByUntilChunkCloses(source, heartbeats.Select(message => message.GetTimestamp()))
+                : source.Publish(shared => GroupByUntilChunkCloses(shared, shared.Select(timeSelector)));
         }
 
         public IObservable<IGroupedObservable<DateTime, Timestamped<TSource>>> Process<TSource>(IObservable<Timestamped<TSource>> source)
-        {
-            return source.GroupBy(value => GetChunkIndex(value.Seconds));
-        }
+            => Process(source, value => value.Seconds, value => value, heartbeats: null);
 
         public IObservable<IGroupedObservable<DateTime, HarpMessage>> Process(IObservable<HarpMessage> source)
-        {
-            return source.GroupBy(value => GetChunkIndex(value.GetTimestamp()));
-        }
+            => Process(source, value => value.GetTimestamp(), value => value, heartbeats: null);
 
         public IObservable<IGroupedObservable<DateTime, Timestamped<TSource>>> Process<TSource>(IObservable<Tuple<TSource, double>> source)
-        {
-            return source.GroupBy(value => GetChunkIndex(value.Item2), value => Timestamped.Create(value.Item1, value.Item2));
-        }
-
-        bool ShouldCloseChunk<TElement>(IGroupedObservable<DateTime, TElement> chunk, HarpMessage heartbeat)
-        {
-            var beatTimestamp = ReferenceTime.AddSeconds(heartbeat.GetTimestamp());
-            var beatDelta = beatTimestamp - chunk.Key;
-            return beatDelta > new TimeSpan(ChunkSize, 0, 0) + ClosingDuration;
-        }
+            => Process(source, value => value.Item2, value => Timestamped.Create(value.Item1, value.Item2), heartbeats: null);
 
         public IObservable<IGroupedObservable<DateTime, Timestamped<TSource>>> Process<TSource>(
             IObservable<Timestamped<TSource>> source,
             IObservable<HarpMessage> heartbeats)
-        {
-            return source.GroupByUntil(
-                value => GetChunkIndex(value.Seconds),
-                chunk => heartbeats.FirstOrDefaultAsync(message => ShouldCloseChunk(chunk, message)));
-        }
+            => Process(source, value => value.Seconds, value => value, heartbeats);
 
         public IObservable<IGroupedObservable<DateTime, HarpMessage>> Process(
             IObservable<HarpMessage> source,
             IObservable<HarpMessage> heartbeats)
-        {
-            return source.GroupByUntil(
-                value => GetChunkIndex(value.GetTimestamp()),
-                chunk => heartbeats.FirstOrDefaultAsync(message => ShouldCloseChunk(chunk, message)));
-        }
+            => Process(source, value => value.GetTimestamp(), value => value, heartbeats);
 
         public IObservable<IGroupedObservable<DateTime, Timestamped<TSource>>> Process<TSource>(
             IObservable<Tuple<TSource, double>> source,
             IObservable<HarpMessage> heartbeats)
-        {
-            return source.GroupByUntil(
-                value => GetChunkIndex(value.Item2), value => Timestamped.Create(value.Item1, value.Item2),
-                chunk => heartbeats.FirstOrDefaultAsync(message => ShouldCloseChunk(chunk, message)));
-        }
+            => Process(source, value => value.Item2, value => Timestamped.Create(value.Item1, value.Item2), heartbeats);
     }
 }

--- a/src/Aeon.Acquisition/GroupByTime.cs
+++ b/src/Aeon.Acquisition/GroupByTime.cs
@@ -60,6 +60,13 @@ namespace Aeon.Acquisition
             return elementDelta > new TimeSpan(chunkSize, 0, 0) + closingDuration;
         }
 
+        static IObservable<double> HeartbeatClock(IObservable<HarpMessage> heartbeats)
+        {
+            return heartbeats.Select(message => message.GetTimestamp()).Concat(
+                Observable.Throw<double>(new InvalidOperationException(
+                    "The heartbeat sequence terminated before the source sequence.")));
+        }
+
         IObservable<IGroupedObservable<DateTime, TResult>> Process<TSource, TResult>(
             IObservable<TSource> source,
             Func<TSource, double> timeSelector,
@@ -78,7 +85,7 @@ namespace Aeon.Acquisition
                     chunk => clock.FirstOrDefaultAsync(seconds => ShouldCloseChunk(chunk.Key, seconds, chunkSize, closingDuration.GetValueOrDefault())));
 
             return heartbeats != null
-                ? GroupByUntilChunkCloses(source, heartbeats.Select(message => message.GetTimestamp()))
+                ? GroupByUntilChunkCloses(source, HeartbeatClock(heartbeats))
                 : source.Publish(shared => GroupByUntilChunkCloses(shared, shared.Select(timeSelector)));
         }
 

--- a/src/Aeon.Acquisition/LogAudio.bonsai
+++ b/src/Aeon.Acquisition/LogAudio.bonsai
@@ -31,7 +31,11 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
           <aeon:ChunkSize>1</aeon:ChunkSize>
+          <aeon:ClosingDuration>PT2S</aeon:ClosingDuration>
         </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:DistinctBy">
+        <rx:KeySelector>Key</rx:KeySelector>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="LogName" Description="The base name of the video log, without extension." />
@@ -115,10 +119,11 @@
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="6" Label="Source3" />
       <Edge From="5" To="6" Label="Source4" />
-      <Edge From="6" To="8" Label="Source1" />
-      <Edge From="7" To="8" Label="Source2" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/LogData.bonsai
+++ b/src/Aeon.Acquisition/LogData.bonsai
@@ -31,7 +31,11 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
           <aeon:ChunkSize>1</aeon:ChunkSize>
+          <aeon:ClosingDuration>PT2S</aeon:ClosingDuration>
         </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:DistinctBy">
+        <rx:KeySelector>Key</rx:KeySelector>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="LogName" Description="The base name of the data log, without extension." />
@@ -108,10 +112,11 @@
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="6" Label="Source3" />
       <Edge From="5" To="6" Label="Source4" />
-      <Edge From="6" To="8" Label="Source1" />
-      <Edge From="7" To="8" Label="Source2" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/LogHarp.bonsai
+++ b/src/Aeon.Acquisition/LogHarp.bonsai
@@ -29,7 +29,11 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
           <aeon:ChunkSize>1</aeon:ChunkSize>
+          <aeon:ClosingDuration>PT2S</aeon:ClosingDuration>
         </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:DistinctBy">
+        <rx:KeySelector>Key</rx:KeySelector>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="LogName" Description="The base name of the data log, without extension." />
@@ -106,10 +110,11 @@
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="6" Label="Source3" />
       <Edge From="5" To="6" Label="Source4" />
-      <Edge From="6" To="8" Label="Source1" />
-      <Edge From="7" To="8" Label="Source2" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Acquisition/LogHarpDemux.bonsai
+++ b/src/Aeon.Acquisition/LogHarpDemux.bonsai
@@ -85,7 +85,11 @@
             <Expression xsi:type="Combinator">
               <Combinator xsi:type="aeon:GroupByTime">
                 <aeon:ChunkSize>1</aeon:ChunkSize>
+                <aeon:ClosingDuration>PT2S</aeon:ClosingDuration>
               </Combinator>
+            </Expression>
+            <Expression xsi:type="rx:DistinctBy">
+              <rx:KeySelector>Key</rx:KeySelector>
             </Expression>
             <Expression xsi:type="rx:CreateObservable">
               <Name>LogHarp</Name>
@@ -177,6 +181,7 @@
             <Edge From="17" To="18" Label="Source1" />
             <Edge From="18" To="19" Label="Source1" />
             <Edge From="19" To="20" Label="Source1" />
+            <Edge From="20" To="21" Label="Source1" />
           </Edges>
         </Workflow>
       </Expression>

--- a/src/Aeon.Acquisition/LogHarpState.bonsai
+++ b/src/Aeon.Acquisition/LogHarpState.bonsai
@@ -23,7 +23,6 @@
       </Expression>
       <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarp.bonsai">
         <Heartbeats xsi:nil="true" />
-        <ClosingDuration xsi:nil="true" />
         <LogName>HarpData</LogName>
       </Expression>
       <Expression xsi:type="rx:Condition">
@@ -53,7 +52,6 @@
       <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarpDemux.bonsai">
         <LogName>HarpData</LogName>
         <Heartbeats />
-        <ClosingDuration xsi:nil="true" />
       </Expression>
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="rx:Merge" />

--- a/src/Aeon.Acquisition/LogJson.bonsai
+++ b/src/Aeon.Acquisition/LogJson.bonsai
@@ -31,7 +31,11 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
           <aeon:ChunkSize>1</aeon:ChunkSize>
+          <aeon:ClosingDuration>PT2S</aeon:ClosingDuration>
         </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:DistinctBy">
+        <rx:KeySelector>Key</rx:KeySelector>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="LogName" Description="The base name of the data log, without extension." />
@@ -107,10 +111,11 @@
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="6" Label="Source3" />
       <Edge From="5" To="6" Label="Source4" />
-      <Edge From="6" To="8" Label="Source1" />
-      <Edge From="7" To="8" Label="Source2" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Tests/GroupByTimeTests.cs
+++ b/src/Aeon.Tests/GroupByTimeTests.cs
@@ -230,6 +230,42 @@ namespace Aeon.Tests
         }
 
         [TestMethod]
+        public void Process_HeartbeatCompletesBeforeSource_RaisesError()
+        {
+            var source = new Subject<Timestamped<int>>();
+            var heartbeats = new Subject<HarpMessage>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.Zero };
+            Exception error = null;
+            using (groupByTime.Process(source, heartbeats).Subscribe(_ => { }, exception => error = exception))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                heartbeats.OnCompleted();
+            }
+
+            Assert.IsInstanceOfType<InvalidOperationException>(error);
+        }
+
+        [TestMethod]
+        public void Process_SourceCompletesWithoutHeartbeat_CompletesWithoutError()
+        {
+            // A source without a heartbeat is its own clock, so the clock terminating is the source
+            // terminating and must not be reported as a heartbeat that stopped early.
+            var source = new Subject<Timestamped<int>>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.Zero };
+            Exception error = null;
+            var completed = false;
+            using (groupByTime.Process(source).Subscribe(_ => { }, exception => error = exception, () => completed = true))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                source.OnNext(Timestamped.Create(2, 3660));
+                source.OnCompleted();
+            }
+
+            Assert.IsNull(error);
+            Assert.IsTrue(completed);
+        }
+
+        [TestMethod]
         public void Process_ChunkSizeChangedAfterProcessCall_UsesCapturedChunkSize()
         {
             var source = new Subject<Timestamped<int>>();

--- a/src/Aeon.Tests/GroupByTimeTests.cs
+++ b/src/Aeon.Tests/GroupByTimeTests.cs
@@ -1,0 +1,251 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Xml;
+using System.Xml.Linq;
+using Aeon.Acquisition;
+using Bonsai;
+using Bonsai.Expressions;
+using Bonsai.Harp;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Aeon.Tests
+{
+    [TestClass]
+    public class GroupByTimeTests
+    {
+        static string SerializeWorkflow(GroupByTime operatorInstance)
+        {
+            using var writer = new StringWriter();
+            var builder = new WorkflowBuilder { Workflow = { new CombinatorBuilder { Combinator = operatorInstance } } };
+            WorkflowBuilder.Serializer.Serialize(writer, builder);
+            return writer.ToString();
+        }
+
+        static GroupByTime DeserializeWorkflow(string xml)
+        {
+            using var reader = XmlReader.Create(new StringReader(xml));
+            reader.MoveToContent();
+            var builder = (WorkflowBuilder)WorkflowBuilder.Serializer.Deserialize(reader);
+            return (GroupByTime)ExpressionBuilder.GetWorkflowElement(builder.Workflow.Single().Value);
+        }
+
+        sealed class GroupTracker<TElement>
+        {
+            public List<DateTime> Opened { get; } = new();
+
+            public List<DateTime> Completed { get; } = new();
+
+            public IDisposable Subscribe(IObservable<IGroupedObservable<DateTime, TElement>> grouped)
+            {
+                return grouped.Subscribe(group =>
+                {
+                    Opened.Add(group.Key);
+                    group.Subscribe(_ => { }, () => Completed.Add(group.Key));
+                });
+            }
+        }
+
+        [TestMethod]
+        public void Process_ClosingDurationZero_ClosesChunkWhenNextChunkArrives()
+        {
+            var source = new Subject<Timestamped<int>>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.Zero };
+            var tracker = new GroupTracker<Timestamped<int>>();
+            using (tracker.Subscribe(groupByTime.Process(source)))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                source.OnNext(Timestamped.Create(2, 1800));
+                Assert.IsEmpty(tracker.Completed);
+                source.OnNext(Timestamped.Create(3, 3660));
+                Assert.HasCount(1, tracker.Completed);
+                Assert.AreEqual(tracker.Opened[0], tracker.Completed[0]);
+                source.OnCompleted();
+            }
+
+            Assert.HasCount(2, tracker.Opened);
+            Assert.AreNotEqual(tracker.Opened[0], tracker.Opened[1]);
+            Assert.AreSequenceEqual(tracker.Opened, tracker.Completed);
+        }
+
+        [TestMethod]
+        public void Process_ClosingDurationNull_KeepsChunksOpenUntilSourceCompletes()
+        {
+            var source = new Subject<Timestamped<int>>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = null };
+            var tracker = new GroupTracker<Timestamped<int>>();
+            using (tracker.Subscribe(groupByTime.Process(source)))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                source.OnNext(Timestamped.Create(2, 3660));
+                Assert.IsEmpty(tracker.Completed);
+                source.OnCompleted();
+            }
+
+            Assert.HasCount(2, tracker.Opened);
+            Assert.HasCount(2, tracker.Completed);
+        }
+
+        [TestMethod]
+        public void Process_ClosingDurationZero_ReopensChunkForLateElement()
+        {
+            var source = new Subject<Timestamped<int>>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.Zero };
+            var tracker = new GroupTracker<Timestamped<int>>();
+            using (tracker.Subscribe(groupByTime.Process(source)))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                source.OnNext(Timestamped.Create(2, 3660));
+                source.OnNext(Timestamped.Create(3, 60));
+                source.OnCompleted();
+            }
+
+            Assert.HasCount(3, tracker.Opened);
+            Assert.AreNotEqual(tracker.Opened[0], tracker.Opened[1]);
+            Assert.AreEqual(tracker.Opened[0], tracker.Opened[2]);
+        }
+
+        [TestMethod]
+        public void Process_ClosingDurationGrace_KeepsChunkOpenWithinGrace()
+        {
+            var source = new Subject<Timestamped<int>>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.FromMinutes(30) };
+            var tracker = new GroupTracker<Timestamped<int>>();
+            using (tracker.Subscribe(groupByTime.Process(source)))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                source.OnNext(Timestamped.Create(2, 3600));
+                Assert.IsEmpty(tracker.Completed);
+                source.OnNext(Timestamped.Create(3, 5460));
+                Assert.HasCount(1, tracker.Completed);
+                Assert.AreEqual(tracker.Opened[0], tracker.Completed[0]);
+                source.OnCompleted();
+            }
+        }
+
+        [TestMethod]
+        public void Process_TupleSource_ClosesChunkWhenNextChunkArrives()
+        {
+            var source = new Subject<Tuple<int, double>>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.Zero };
+            var tracker = new GroupTracker<Timestamped<int>>();
+            using (tracker.Subscribe(groupByTime.Process(source)))
+            {
+                source.OnNext(Tuple.Create(1, 0.0));
+                source.OnNext(Tuple.Create(2, 3660.0));
+                Assert.HasCount(1, tracker.Completed);
+                Assert.AreEqual(tracker.Opened[0], tracker.Completed[0]);
+                source.OnCompleted();
+            }
+        }
+
+        [TestMethod]
+        public void Process_HarpMessageSource_ClosesChunkWhenNextChunkArrives()
+        {
+            var source = new Subject<HarpMessage>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.Zero };
+            var tracker = new GroupTracker<HarpMessage>();
+            using (tracker.Subscribe(groupByTime.Process(source)))
+            {
+                source.OnNext(HarpMessage.FromByte(32, 0.0, MessageType.Event, 1));
+                source.OnNext(HarpMessage.FromByte(32, 3660.0, MessageType.Event, 2));
+                Assert.HasCount(1, tracker.Completed);
+                Assert.AreEqual(tracker.Opened[0], tracker.Completed[0]);
+                source.OnCompleted();
+            }
+        }
+
+        [TestMethod]
+        public void Serialization_ExplicitNull_RoundTripsAsNull()
+        {
+            var xml = SerializeWorkflow(new GroupByTime { ClosingDuration = null });
+            Assert.Contains("nil", xml);
+            Assert.IsNull(DeserializeWorkflow(xml).ClosingDuration);
+        }
+
+        [TestMethod]
+        public void Serialization_Value_RoundTripsAsValue()
+        {
+            var restored = DeserializeWorkflow(SerializeWorkflow(new GroupByTime { ClosingDuration = TimeSpan.Zero }));
+            Assert.AreEqual(TimeSpan.Zero, restored.ClosingDuration);
+        }
+
+        [TestMethod]
+        public void Deserialization_AbsentElement_UsesConstructorDefault()
+        {
+            var document = XDocument.Parse(SerializeWorkflow(new GroupByTime()));
+            document.Descendants().Where(element => element.Name.LocalName == "ClosingDuration").Remove();
+            var restored = DeserializeWorkflow(document.ToString());
+            Assert.AreEqual(new GroupByTime().ClosingDuration, restored.ClosingDuration);
+        }
+
+        [TestMethod]
+        public void Constructor_DefaultsClosingDurationToNull()
+        {
+            Assert.IsNull(new GroupByTime().ClosingDuration);
+        }
+
+        [TestMethod]
+        public void Process_HeartbeatAdvancesPastChunk_ClosesChunk()
+        {
+            var source = new Subject<Timestamped<int>>();
+            var heartbeats = new Subject<HarpMessage>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.Zero };
+            var tracker = new GroupTracker<Timestamped<int>>();
+            using (tracker.Subscribe(groupByTime.Process(source, heartbeats)))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                heartbeats.OnNext(HarpMessage.FromByte(32, 1800.0, MessageType.Event, 1));
+                Assert.IsEmpty(tracker.Completed);
+                heartbeats.OnNext(HarpMessage.FromByte(32, 3660.0, MessageType.Event, 2));
+                Assert.HasCount(1, tracker.Completed);
+                Assert.AreEqual(tracker.Opened[0], tracker.Completed[0]);
+                source.OnCompleted();
+                heartbeats.OnCompleted();
+            }
+        }
+
+        [TestMethod]
+        public void Process_HeartbeatCompletesWithNullClosingDuration_KeepsChunksOpenUntilSourceCompletes()
+        {
+            var source = new Subject<Timestamped<int>>();
+            var heartbeats = new Subject<HarpMessage>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = null };
+            var tracker = new GroupTracker<Timestamped<int>>();
+            using (tracker.Subscribe(groupByTime.Process(source, heartbeats)))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                source.OnNext(Timestamped.Create(2, 3660));
+                heartbeats.OnNext(HarpMessage.FromByte(32, 7260.0, MessageType.Event, 1));
+                heartbeats.OnCompleted();
+                Assert.IsEmpty(tracker.Completed);
+                source.OnCompleted();
+            }
+
+            Assert.HasCount(2, tracker.Opened);
+            Assert.HasCount(2, tracker.Completed);
+        }
+
+        [TestMethod]
+        public void Process_ChunkSizeChangedAfterProcessCall_UsesCapturedChunkSize()
+        {
+            var source = new Subject<Timestamped<int>>();
+            var groupByTime = new GroupByTime { ChunkSize = 1, ClosingDuration = TimeSpan.Zero };
+            var tracker = new GroupTracker<Timestamped<int>>();
+            var grouped = groupByTime.Process(source);
+            groupByTime.ChunkSize = 2;
+            using (tracker.Subscribe(grouped))
+            {
+                source.OnNext(Timestamped.Create(1, 0));
+                source.OnNext(Timestamped.Create(2, 3660));
+                source.OnCompleted();
+            }
+
+            Assert.HasCount(2, tracker.Opened);
+            Assert.AreNotEqual(tracker.Opened[0], tracker.Opened[1]);
+        }
+    }
+}

--- a/src/Aeon.Video/LogVideo.bonsai
+++ b/src/Aeon.Video/LogVideo.bonsai
@@ -32,7 +32,11 @@
       <Expression xsi:type="Combinator">
         <Combinator xsi:type="aeon:GroupByTime">
           <aeon:ChunkSize>1</aeon:ChunkSize>
+          <aeon:ClosingDuration>PT2S</aeon:ClosingDuration>
         </Combinator>
+      </Expression>
+      <Expression xsi:type="rx:DistinctBy">
+        <rx:KeySelector>Key</rx:KeySelector>
       </Expression>
       <Expression xsi:type="ExternalizedMapping">
         <Property Name="Name" DisplayName="LogName" Description="The base name of the video log, without extension." />
@@ -149,10 +153,11 @@
       <Edge From="3" To="4" Label="Source1" />
       <Edge From="4" To="6" Label="Source3" />
       <Edge From="5" To="6" Label="Source4" />
-      <Edge From="6" To="8" Label="Source1" />
-      <Edge From="7" To="8" Label="Source2" />
-      <Edge From="8" To="9" Label="Source1" />
+      <Edge From="6" To="7" Label="Source1" />
+      <Edge From="7" To="9" Label="Source1" />
+      <Edge From="8" To="9" Label="Source2" />
       <Edge From="9" To="10" Label="Source1" />
+      <Edge From="10" To="11" Label="Source1" />
     </Edges>
   </Workflow>
 </WorkflowBuilder>

--- a/src/Aeon.Vision.Sleap/LogPoseTracking.bonsai
+++ b/src/Aeon.Vision.Sleap/LogPoseTracking.bonsai
@@ -96,7 +96,6 @@
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Acquisition:LogHarp.bonsai">
               <Heartbeats xsi:nil="true" />
-              <ClosingDuration xsi:nil="true" />
               <LogName>PoseTrackingData</LogName>
             </Expression>
             <Expression xsi:type="WorkflowOutput" />


### PR DESCRIPTION
`GroupByTime` without a clock source used a plain `GroupBy` on the chunk key, meaning each group would never complete and would stay open until the source ended. This accumulated a never-completing group per chunk over a long run, and although the data loggers would finalize subscriptions to previous chunks once a later one arrived, `OnCompleted` would never be called. This PR completes each group by default in all loggers, unifies the implementation and behavior of the `GroupByTime` primitive, and requires a heartbeat clock to outlive the source sequence.

## Opt-in chunk closing

All `Process` overloads now route through a single implementation that closes each chunk once the clock advances past the chunk end plus `ClosingDuration`, collapsing the previously separate heartbeat and no-heartbeat paths. A heartbeat source still provides the explicit clock, while a source without a heartbeat now acts as its own clock.

`ClosingDuration` defaults to `null`, which keeps each chunk open until the sequence terminates, matching the previous default behavior and ensuring backward compatibility for any custom workflow using `GroupByTime` directly. A `null` round-trips as `xsi:nil` so the opt-out is now explicit. `ChunkSize` and `ClosingDuration` are read once when the sequence is created, so a running property mapping cannot resize open chunks.

## The heartbeat contract

A heartbeat source is the clock that closes chunks, so it may not terminate before the source sequence. If it does, the grouped sequence faults with an `InvalidOperationException`.

Without this, a terminating heartbeat closed every open chunk and then opened and immediately closed a new group for each element that followed, all carrying the same chunk key. The loggers dropped those as duplicates, so a run wrote nothing from that point on without reporting anything. Before this PR the same condition sent a duplicate chunk key to the writer, which terminated the run on an existing file name, so faulting restores a reported failure and names its cause.

This contract applies only to the heartbeat overloads. A source without a heartbeat is its own clock, which cannot outlive it, so there is nothing to enforce.

## Closing logger chunks by default

The data loggers now set `ClosingDuration` to two seconds by default, sized to the Harp synchronization model. Sync pulses are broadcast on the whole-second boundary and a device may step backward around a boundary but never beyond one sync period, so a two-second grace period is enough that such a step does not reopen a chunk that has already closed.

A larger backward step, for example connecting a new synchronizer, can exceed the grace period and reopen a closed chunk, so each logger uses `DistinctBy` on the chunk key to drop resurrected chunks before they reach the writer. The same drop already happens today, because the loggers flatten chunks with `Switch`, which itself closes the previous chunk's writer as soon as the next chunk opens, so a late element reaches a writer whose subscription is already gone. With the heartbeat contract above, this drop now covers only a backward step under a live clock.

Closes #171
