### PR TITLE
Add repository provenance metadata operator

### DIFF
--- a/src/Aeon.Acquisition/GetRepositoryMetadata.cs
+++ b/src/Aeon.Acquisition/GetRepositoryMetadata.cs
@@ -27,11 +27,7 @@ namespace Aeon.Acquisition
                     throw new InvalidOperationException("The repository has no remote named 'origin'.");
                 }
 
-                return new RepositoryMetadata
-                {
-                    Commit = tip.Sha,
-                    Url = remote.Url,
-                };
+                return new RepositoryMetadata(tip.Sha, remote.Url);
             });
         }
     }

--- a/src/Aeon.Acquisition/GetRepositoryMetadata.cs
+++ b/src/Aeon.Acquisition/GetRepositoryMetadata.cs
@@ -1,0 +1,38 @@
+using Bonsai;
+using System;
+using System.ComponentModel;
+using System.Reactive.Linq;
+using LibGit2Sharp;
+
+namespace Aeon.Acquisition
+{
+    [Combinator]
+    [WorkflowElementCategory(ElementCategory.Transform)]
+    [Description("Retrieves provenance metadata for a repository.")]
+    public class GetRepositoryMetadata
+    {
+        public IObservable<RepositoryMetadata> Process(IObservable<IRepository> source)
+        {
+            return source.Select(value =>
+            {
+                var tip = value.Head.Tip;
+                if (tip == null)
+                {
+                    throw new InvalidOperationException("The repository has no commits at the current head.");
+                }
+
+                var remote = value.Network.Remotes["origin"];
+                if (remote == null)
+                {
+                    throw new InvalidOperationException("The repository has no remote named 'origin'.");
+                }
+
+                return new RepositoryMetadata
+                {
+                    Commit = tip.Sha,
+                    Url = remote.Url,
+                };
+            });
+        }
+    }
+}

--- a/src/Aeon.Acquisition/RepositoryMetadata.cs
+++ b/src/Aeon.Acquisition/RepositoryMetadata.cs
@@ -5,10 +5,21 @@ namespace Aeon.Acquisition
     [Description("Represents provenance metadata for a repository.")]
     public class RepositoryMetadata
     {
+        public RepositoryMetadata(string commit, string url)
+        {
+            Commit = commit;
+            Url = url;
+        }
+
         [Description("The commit hash at the current tip of the repository.")]
-        public string Commit { get; set; }
+        public string Commit { get; }
 
         [Description("The URL of the origin remote of the repository.")]
-        public string Url { get; set; }
+        public string Url { get; }
+
+        public override string ToString()
+        {
+            return $"RepositoryMetadata(Commit:{Commit}, Url:{Url})";
+        }
     }
 }

--- a/src/Aeon.Acquisition/RepositoryMetadata.cs
+++ b/src/Aeon.Acquisition/RepositoryMetadata.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel;
+
+namespace Aeon.Acquisition
+{
+    [Description("Represents provenance metadata for a repository.")]
+    public class RepositoryMetadata
+    {
+        [Description("The commit hash at the current tip of the repository.")]
+        public string Commit { get; set; }
+
+        [Description("The URL of the origin remote of the repository.")]
+        public string Url { get; set; }
+    }
+}


### PR DESCRIPTION
`GetRepositoryMetadata` reads the commit hash at the current tip and the `origin` remote's URL from a repository into a new `RepositoryMetadata` value carrying its `Commit` and `Url`, to record the provenance of experiment data. It throws if the repository has no commit or no `origin` remote.

Today the experiments extract these two values inline and recombine them with `Zip` and an anonymous type before property-mapping. A single operator emitting the pair removes that recombination, so a workflow property-maps `Commit` and `Url` straight onto the generated `Experiment` metadata. `RepositoryMetadata` is an Aeon-owned carrier, not the serialized schema, and extends with further SourceLink-style fields such as branch and type if the metadata schema grows.

The `origin` URL is taken raw with no normalization, and `origin` is hardcoded to match git clone's default remote. A `RemoteName` property can be added later without a breaking change.

Closes #241