### PR TITLE
Multicast NeuropixelsV2eBeta data into its subjects

### DIFF
--- a/src/Aeon.Ephys/NeuropixelsV2eBeta.bonsai
+++ b/src/Aeon.Ephys/NeuropixelsV2eBeta.bonsai
@@ -14,10 +14,10 @@
       <Expression xsi:type="rx:PublishSubject" TypeArguments="harp:Timestamped(onix1:HarpSyncInputDataFrame)">
         <rx:Name>OnixHarpSync</rx:Name>
       </Expression>
-      <Expression xsi:type="rx:PublishSubject" TypeArguments="onix1:NeuropixelsV2DataFrame">
+      <Expression xsi:type="rx:PublishSubject" TypeArguments="onix1:NeuropixelsV2eBetaDataFrame">
         <rx:Name>NeuropixelsV2eBetaProbeA</rx:Name>
       </Expression>
-      <Expression xsi:type="rx:PublishSubject" TypeArguments="onix1:NeuropixelsV2DataFrame">
+      <Expression xsi:type="rx:PublishSubject" TypeArguments="onix1:NeuropixelsV2eBetaDataFrame">
         <rx:Name>NeuropixelsV2eBetaProbeB</rx:Name>
       </Expression>
       <Expression xsi:type="rx:PublishSubject" TypeArguments="onix1:Bno055DataFrame">
@@ -289,7 +289,7 @@
                 </Edges>
               </Workflow>
             </Expression>
-            <Expression xsi:type="rx:PublishSubject">
+            <Expression xsi:type="MulticastSubject">
               <Name>NeuropixelsV2eBetaProbeA</Name>
             </Expression>
             <Expression xsi:type="SubscribeSubject">
@@ -335,7 +335,7 @@
                 </Edges>
               </Workflow>
             </Expression>
-            <Expression xsi:type="rx:PublishSubject">
+            <Expression xsi:type="MulticastSubject">
               <Name>NeuropixelsV2eBetaProbeB</Name>
             </Expression>
             <Expression xsi:type="Combinator">
@@ -344,7 +344,7 @@
                 <onix1:PolledRegisters>All</onix1:PolledRegisters>
               </Combinator>
             </Expression>
-            <Expression xsi:type="rx:PublishSubject">
+            <Expression xsi:type="MulticastSubject">
               <Name>NeuropixelsV2eBetaBno055</Name>
             </Expression>
             <Expression xsi:type="IncludeWorkflow" Path="Aeon.Ephys:OnixDeviceMonitor.bonsai" />


### PR DESCRIPTION
This PR fixes a bug in the NeuropixelsV2eBeta include workflow, which was streaming the probe and IMU data through a `PublishSubject` inside of a `SelectMany` instead of a `MulticastSubject`. Because a `PublishSubject` declares a new subject local to the nested scope, the inner nodes shadowed the subjects declared at the top of the workflow rather than writing into them, so nothing subscribing `NeuropixelsV2eBetaProbeA`, `NeuropixelsV2eBetaProbeB` or `NeuropixelsV2eBetaBno055` received any data. The workflow still built, since a same-named subject in a different scope is legal, so the failure was silent.

The two probe declarations also carried `NeuropixelsV2DataFrame` rather than `NeuropixelsV2eBetaDataFrame`. Both derive from `BufferedDataFrame` with no inheritance relation between them, so the multicast does not type-check against the wrong declared type and the correction is part of the same fix.

The other `NeuropixelsV2e` and `Headstage64` workflows were unaffected, and after the fix the workflow matches `NeuropixelsV2e.bonsai` in shape.