### PR TITLE
Capture regions when the sequence is subscribed

### DIFF
--- a/src/Aeon.Vision/RegionContainsPoint.cs
+++ b/src/Aeon.Vision/RegionContainsPoint.cs
@@ -36,29 +36,40 @@ namespace Aeon.Vision
 
         public IObservable<Timestamped<bool>> Process(IObservable<Timestamped<Point2f>> source)
         {
-            return source.Select(x =>
+            return Observable.Defer(() =>
             {
-                var containsPoint = Contains(Regions, x.Value);
-                return Timestamped.Create(containsPoint, x.Seconds);
+                var regions = Regions;
+                return source.Select(x =>
+                {
+                    var containsPoint = Contains(regions, x.Value);
+                    return Timestamped.Create(containsPoint, x.Seconds);
+                });
             });
         }
 
         public IObservable<Timestamped<bool>> Process(IObservable<Timestamped<ConnectedComponent>> source)
         {
-            return source.Select(x =>
+            return Observable.Defer(() =>
             {
-                var containsPoint = Contains(Regions, x.Value.Centroid);
-                return Timestamped.Create(containsPoint, x.Seconds);
+                var regions = Regions;
+                return source.Select(x =>
+                {
+                    var containsPoint = Contains(regions, x.Value.Centroid);
+                    return Timestamped.Create(containsPoint, x.Seconds);
+                });
             });
         }
 
         public IObservable<Timestamped<bool>> Process(IObservable<Timestamped<ConnectedComponentCollection>> source)
         {
-            return source.Select(x =>
+            return Observable.Defer(() =>
             {
                 var regions = Regions;
-                var containsPoint = x.Value.Any(component => Contains(regions, component.Centroid));
-                return Timestamped.Create(containsPoint, x.Seconds);
+                return source.Select(x =>
+                {
+                    var containsPoint = x.Value.Any(component => Contains(regions, component.Centroid));
+                    return Timestamped.Create(containsPoint, x.Seconds);
+                });
             });
         }
     }


### PR DESCRIPTION
`RegionContainsPoint` read `Regions` inside its `Select` lambda, so every element saw whatever the property held at that moment. Under a dynamically instantiated pipeline that is the wrong value: each branch maps its own regions into the same operator instance, so whichever branch assigned last won for all of them. Each `Process` overload now wraps its sequence in `Observable.Defer` and captures `Regions` into the closure, so the value is read once per subscription and each sequence keeps the regions in place when it was subscribed.

## Capture rather than copy

The local workarounds deep-copy the array. This takes the reference instead, on two grounds. Both writers replace the whole value rather than mutating in place, since `PropertyMapping` compiles to an assignment and `IplImageInputRoiEditor` assigns a fresh `regions.ToArray()` through the property descriptor. And a reference read is atomic, so a capture always observes one internally consistent array, whereas a clone racing an in-place mutation could observe a torn one and would not deliver the safety it appears to.

Closes #255
Closes #249
